### PR TITLE
Add Kafka listener and persistence

### DIFF
--- a/src/main/java/se/hydroleaf/kafka/KafkaListeners.java
+++ b/src/main/java/se/hydroleaf/kafka/KafkaListeners.java
@@ -1,0 +1,42 @@
+package se.hydroleaf.kafka;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import se.hydroleaf.service.RecordService;
+
+@Component
+public class KafkaListeners {
+
+    private static final Logger logger = LoggerFactory.getLogger(KafkaListeners.class);
+    private final RecordService recordService;
+
+    public KafkaListeners(RecordService recordService) {
+        this.recordService = recordService;
+    }
+
+    @KafkaListener(topics = "growSensors", groupId = "nft-backend")
+    public void listenGrowSensors(String message) {
+        logger.info("Received growSensors message: {}", message);
+        recordService.saveMessage(message);
+    }
+
+    @KafkaListener(topics = "rootImages", groupId = "nft-backend")
+    public void listenRootImages(String message) {
+        logger.info("Received rootImages message: {}", message);
+        recordService.saveMessage(message);
+    }
+
+    @KafkaListener(topics = "waterOutput", groupId = "nft-backend")
+    public void listenWaterOutput(String message) {
+        logger.info("Received waterOutput message: {}", message);
+        recordService.saveMessage(message);
+    }
+
+    @KafkaListener(topics = "waterTank", groupId = "nft-backend")
+    public void listenWaterTank(String message) {
+        logger.info("Received waterTank message: {}", message);
+        recordService.saveMessage(message);
+    }
+}

--- a/src/main/java/se/hydroleaf/model/SensorRecord.java
+++ b/src/main/java/se/hydroleaf/model/SensorRecord.java
@@ -1,0 +1,74 @@
+package se.hydroleaf.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+
+import java.time.Instant;
+
+@Entity
+public class SensorRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String deviceId;
+    private Instant timestamp;
+    private String location;
+
+    @Lob
+    private String sensors;
+
+    @Lob
+    private String health;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDeviceId() {
+        return deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public String getSensors() {
+        return sensors;
+    }
+
+    public void setSensors(String sensors) {
+        this.sensors = sensors;
+    }
+
+    public String getHealth() {
+        return health;
+    }
+
+    public void setHealth(String health) {
+        this.health = health;
+    }
+}

--- a/src/main/java/se/hydroleaf/repository/SensorRecordRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorRecordRepository.java
@@ -1,0 +1,7 @@
+package se.hydroleaf.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se.hydroleaf.model.SensorRecord;
+
+public interface SensorRecordRepository extends JpaRepository<SensorRecord, Long> {
+}

--- a/src/main/java/se/hydroleaf/service/RecordService.java
+++ b/src/main/java/se/hydroleaf/service/RecordService.java
@@ -1,0 +1,37 @@
+package se.hydroleaf.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import se.hydroleaf.model.SensorRecord;
+import se.hydroleaf.repository.SensorRecordRepository;
+
+import java.io.IOException;
+import java.time.Instant;
+
+@Service
+public class RecordService {
+
+    private final SensorRecordRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public RecordService(SensorRecordRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+    }
+
+    public void saveMessage(String json) {
+        try {
+            JsonNode node = objectMapper.readTree(json);
+            SensorRecord record = new SensorRecord();
+            record.setDeviceId(node.path("deviceId").asText());
+            record.setTimestamp(Instant.parse(node.path("timestamp").asText()));
+            record.setLocation(node.path("location").asText());
+            record.setSensors(node.path("sensors").toString());
+            record.setHealth(node.path("health").toString());
+            repository.save(record);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to parse message", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,11 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: nft-backend
+      auto-offset-reset: earliest
 
 ---
 spring:
@@ -37,3 +42,8 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: nft-backend
+      auto-offset-reset: earliest


### PR DESCRIPTION
## Summary
- persist sensor data with a JPA entity
- add service to parse Kafka messages and save to Postgres
- consume four Kafka topics with `@KafkaListener`
- configure Kafka consumer in `application.yml`

## Testing
- `mvn test` *(fails: unable to download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687edd0dab3c832888a3573409cdfac5