### PR TITLE
Add sensor API endpoints

### DIFF
--- a/src/main/java/se/hydroleaf/controller/SensorController.java
+++ b/src/main/java/se/hydroleaf/controller/SensorController.java
@@ -1,0 +1,56 @@
+package se.hydroleaf.controller;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import se.hydroleaf.model.SensorRecord;
+import se.hydroleaf.service.RecordService;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/sensors")
+public class SensorController {
+
+    private final RecordService recordService;
+
+    public SensorController(RecordService recordService) {
+        this.recordService = recordService;
+    }
+
+    @GetMapping("/latest")
+    public SensorRecord latest() {
+        return recordService.getLatestRecord().orElse(null);
+    }
+
+    @GetMapping("/history")
+    public List<SensorRecord> history(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
+        return recordService.getRecordsBetween(from, to);
+    }
+
+    @GetMapping("/statistics")
+    public Map<String, Double> statistics(
+            @RequestParam String type,
+            @RequestParam String range) {
+        Duration duration = parseDuration(range);
+        return recordService.calculateStatistics(type, duration);
+    }
+
+    private Duration parseDuration(String range) {
+        if (range.endsWith("h")) {
+            long hours = Long.parseLong(range.substring(0, range.length() - 1));
+            return Duration.ofHours(hours);
+        } else if (range.endsWith("d")) {
+            long days = Long.parseLong(range.substring(0, range.length() - 1));
+            return Duration.ofDays(days);
+        }
+        throw new IllegalArgumentException("Unsupported range format: " + range);
+    }
+}

--- a/src/main/java/se/hydroleaf/repository/SensorRecordRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorRecordRepository.java
@@ -1,7 +1,13 @@
 package se.hydroleaf.repository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import se.hydroleaf.model.SensorRecord;
 
 public interface SensorRecordRepository extends JpaRepository<SensorRecord, Long> {
+    Optional<SensorRecord> findTopByOrderByTimestampDesc();
+
+    List<SensorRecord> findByTimestampBetween(Instant from, Instant to);
 }

--- a/src/main/java/se/hydroleaf/service/RecordService.java
+++ b/src/main/java/se/hydroleaf/service/RecordService.java
@@ -7,7 +7,13 @@ import se.hydroleaf.model.SensorRecord;
 import se.hydroleaf.repository.SensorRecordRepository;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 @Service
 public class RecordService {
@@ -33,5 +39,37 @@ public class RecordService {
         } catch (IOException e) {
             throw new RuntimeException("Failed to parse message", e);
         }
+    }
+
+    public Optional<SensorRecord> getLatestRecord() {
+        return repository.findTopByOrderByTimestampDesc();
+    }
+
+    public List<SensorRecord> getRecordsBetween(Instant from, Instant to) {
+        return repository.findByTimestampBetween(from, to);
+    }
+
+    public Map<String, Double> calculateStatistics(String type, Duration range) {
+        Instant to = Instant.now();
+        Instant from = to.minus(range);
+        List<SensorRecord> records = repository.findByTimestampBetween(from, to);
+        List<Double> values = new ArrayList<>();
+        for (SensorRecord r : records) {
+            try {
+                JsonNode node = objectMapper.readTree(r.getSensors());
+                if (node.has(type)) {
+                    values.add(node.get(type).asDouble());
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        double min = values.stream().mapToDouble(Double::doubleValue).min().orElse(Double.NaN);
+        double max = values.stream().mapToDouble(Double::doubleValue).max().orElse(Double.NaN);
+        double avg = values.stream().mapToDouble(Double::doubleValue).average().orElse(Double.NaN);
+        Map<String, Double> stats = new HashMap<>();
+        stats.put("min", min);
+        stats.put("max", max);
+        stats.put("avg", avg);
+        return stats;
     }
 }

--- a/src/test/java/se/hydroleaf/SensorControllerTest.java
+++ b/src/test/java/se/hydroleaf/SensorControllerTest.java
@@ -1,0 +1,48 @@
+package se.hydroleaf;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import se.hydroleaf.model.SensorRecord;
+import se.hydroleaf.repository.SensorRecordRepository;
+
+import java.time.Instant;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SensorControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private SensorRecordRepository repository;
+
+    @BeforeEach
+    void setup() {
+        repository.deleteAll();
+        SensorRecord record = new SensorRecord();
+        record.setDeviceId("dev1");
+        record.setTimestamp(Instant.now());
+        record.setLocation("loc");
+        record.setSensors("{\"temperature\":20.5}");
+        record.setHealth("{}");
+        repository.save(record);
+    }
+
+    @Test
+    void latestShouldReturnRecord() throws Exception {
+        mvc.perform(get("/api/sensors/latest"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.deviceId").value("dev1"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `SensorController` with `/api/sensors` routes
- extend `RecordService` with retrieval and statistics methods
- extend `SensorRecordRepository` with query methods
- add integration test for new endpoints

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687edf2d55208328a4ad77c95f4b0ac5