### PR TITLE
Add Docker push step to workflow

### DIFF
--- a/.github/workflows/springboot.yml
+++ b/.github/workflows/springboot.yml
@@ -22,3 +22,18 @@ jobs:
 
       - name: Build with Maven
         run: mvn clean install -DskipTests=false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/nft-backend:latest


### PR DESCRIPTION
## Summary
- build Docker image after Maven build passes
- push the image to Docker Hub using configured secrets

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/...)*

------
https://chatgpt.com/codex/tasks/task_e_687ff0c89e4c83288380df1dddd55c48