### PR TITLE
Persist full MQTT payload

### DIFF
--- a/src/main/java/se/hydroleaf/model/SensorRecord.java
+++ b/src/main/java/se/hydroleaf/model/SensorRecord.java
@@ -18,6 +18,11 @@ public class SensorRecord {
     private Instant timestamp;
     private String location;
 
+    private String topic;
+
+    @Lob
+    private String payload;
+
     @Lob
     private String sensors;
 
@@ -54,6 +59,22 @@ public class SensorRecord {
 
     public void setLocation(String location) {
         this.location = location;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public void setPayload(String payload) {
+        this.payload = payload;
     }
 
     public String getSensors() {

--- a/src/main/java/se/hydroleaf/mqtt/MqttService.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttService.java
@@ -71,7 +71,7 @@ public class MqttService implements MqttCallback {
     public void messageArrived(String topic, MqttMessage message) {
         String payload = new String(message.getPayload());
         logger.debug("Received MQTT message on {}: {}", topic, payload);
-        recordService.saveMessage(payload);
+        recordService.saveMessage(topic, payload);
         messagingTemplate.convertAndSend("/topic/" + topic, payload);
     }
 

--- a/src/main/java/se/hydroleaf/service/RecordService.java
+++ b/src/main/java/se/hydroleaf/service/RecordService.java
@@ -20,13 +20,15 @@ public class RecordService {
         this.objectMapper = objectMapper;
     }
 
-    public void saveMessage(String json) {
+    public void saveMessage(String topic, String json) {
         try {
             JsonNode node = objectMapper.readTree(json);
             SensorRecord record = new SensorRecord();
             record.setDeviceId(node.path("deviceId").asText());
             record.setTimestamp(Instant.parse(node.path("timestamp").asText()));
             record.setLocation(node.path("location").asText());
+            record.setTopic(topic);
+            record.setPayload(json);
             record.setSensors(node.path("sensors").toString());
             record.setHealth(node.path("health").toString());
             repository.save(record);


### PR DESCRIPTION
## Summary
- add `payload` field to `SensorRecord`
- save raw MQTT message body along with topic information

## Testing
- `./mvnw -q test` *(fails: unable to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68800a8158e483288881bc8602007c4a