### PR TITLE
Add sensor history API

### DIFF
--- a/src/main/java/se/hydroleaf/controller/SensorRecordController.java
+++ b/src/main/java/se/hydroleaf/controller/SensorRecordController.java
@@ -1,0 +1,31 @@
+package se.hydroleaf.controller;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import se.hydroleaf.model.SensorRecord;
+import se.hydroleaf.service.RecordService;
+
+import java.time.Instant;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/sensors")
+public class SensorRecordController {
+
+    private final RecordService recordService;
+
+    public SensorRecordController(RecordService recordService) {
+        this.recordService = recordService;
+    }
+
+    @GetMapping("/history")
+    public List<SensorRecord> getHistory(
+            @RequestParam("espId") String espId,
+            @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
+        return recordService.getRecords(espId, from, to);
+    }
+}

--- a/src/main/java/se/hydroleaf/repository/SensorRecordRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorRecordRepository.java
@@ -3,5 +3,9 @@ package se.hydroleaf.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import se.hydroleaf.model.SensorRecord;
 
+import java.time.Instant;
+import java.util.List;
+
 public interface SensorRecordRepository extends JpaRepository<SensorRecord, Long> {
+    List<SensorRecord> findByDevice_IdAndTimestampBetween(String deviceId, Instant from, Instant to);
 }

--- a/src/main/java/se/hydroleaf/service/RecordService.java
+++ b/src/main/java/se/hydroleaf/service/RecordService.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+
 @Service
 public class RecordService {
 
@@ -88,5 +89,10 @@ public class RecordService {
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse and save message", e);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<SensorRecord> getRecords(String deviceId, Instant from, Instant to) {
+        return recordRepository.findByDevice_IdAndTimestampBetween(deviceId, from, to);
     }
 }


### PR DESCRIPTION
## Summary
- implement GET `/api/sensors/history` endpoint
- enable querying records by device and timestamp range

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6882b1a22da08328afa7a2b14de0d1f0