### PR TITLE
Add health endpoint

### DIFF
--- a/src/main/java/se/hydroleaf/controller/HealthController.java
+++ b/src/main/java/se/hydroleaf/controller/HealthController.java
@@ -1,0 +1,14 @@
+package se.hydroleaf.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class HealthController {
+    @GetMapping("/health")
+    public String health() {
+        return "OK";
+    }
+}

--- a/src/test/java/se/hydroleaf/controller/HealthControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/HealthControllerTest.java
@@ -1,0 +1,26 @@
+package se.hydroleaf.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HealthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void healthEndpointReturnsOk() throws Exception {
+        mockMvc.perform(get("/api/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("OK"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint
- test that `/api/health` returns `OK`

## Testing
- `./mvnw -q test` *(fails: failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68831f0369c8832890d3f3fdbcb08e9c