### PR TITLE
Add aggregated history endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,8 @@ docker run -p 8080:8080 \
   nft-backend
 ```
 
+
+## REST Endpoints
+
+* `GET /api/sensors/history` - returns sensor records in chronological order.
+* `GET /api/sensors/history/aggregated` - groups values by sensor and lists timestamp/value pairs.

--- a/src/main/java/se/hydroleaf/controller/SensorRecordController.java
+++ b/src/main/java/se/hydroleaf/controller/SensorRecordController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import se.hydroleaf.dto.SensorRecordResponse;
+import se.hydroleaf.dto.AggregatedHistoryResponse;
 import se.hydroleaf.service.RecordService;
 
 import java.time.Instant;
@@ -27,5 +28,13 @@ public class SensorRecordController {
             @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
             @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
         return recordService.getRecords(espId, from, to);
+    }
+
+    @GetMapping("/history/aggregated")
+    public AggregatedHistoryResponse getHistoryAggregated(
+            @RequestParam("espId") String espId,
+            @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
+            @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
+        return recordService.getAggregatedRecords(espId, from, to);
     }
 }

--- a/src/main/java/se/hydroleaf/dto/AggregatedHistoryResponse.java
+++ b/src/main/java/se/hydroleaf/dto/AggregatedHistoryResponse.java
@@ -1,0 +1,10 @@
+package se.hydroleaf.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record AggregatedHistoryResponse(
+        Instant fromDate,
+        Instant toDate,
+        List<AggregatedSensorData> sensors
+) {}

--- a/src/main/java/se/hydroleaf/dto/AggregatedSensorData.java
+++ b/src/main/java/se/hydroleaf/dto/AggregatedSensorData.java
@@ -1,0 +1,10 @@
+package se.hydroleaf.dto;
+
+import java.util.List;
+
+public record AggregatedSensorData(
+        String sensorId,
+        String type,
+        String unit,
+        List<TimestampValue> data
+) {}

--- a/src/main/java/se/hydroleaf/dto/TimestampValue.java
+++ b/src/main/java/se/hydroleaf/dto/TimestampValue.java
@@ -1,0 +1,8 @@
+package se.hydroleaf.dto;
+
+import java.time.Instant;
+
+public record TimestampValue(
+        Instant timestamp,
+        Object value
+) {}


### PR DESCRIPTION
## Summary
- add new response DTOs for compact historical data
- implement aggregation logic in `RecordService`
- expose `/api/sensors/history/aggregated` endpoint
- document REST endpoints in README

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM because the build needs internet access)*

------
https://chatgpt.com/codex/tasks/task_e_688340b8ee888328b98759cb26baae82