### PR TITLE
Store spectral data values in separate rows

### DIFF
--- a/src/main/java/se/hydroleaf/model/SensorData.java
+++ b/src/main/java/se/hydroleaf/model/SensorData.java
@@ -5,10 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 
-import java.util.Map;
 
 @Entity
 @Table(name = "sensor_data")
@@ -24,11 +21,9 @@ public class SensorData {
     private String sensorId;
     private String type;
     private String unit;
-    private Double numericValue;
 
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(name = "spectrum_json", columnDefinition = "jsonb")
-    private Map<String, Integer> spectrumJson;
+    @Column(name = "numeric_value")
+    private Double numericValue;
 
     @Column(name = "value", columnDefinition = "text")  // can be number, string, or JSON structure
     private String sensorValue;

--- a/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
@@ -18,7 +18,7 @@ public interface SensorDataRepository extends JpaRepository<SensorData, Long> {
               sd.type AS type,
               sd.unit AS unit,
             to_timestamp(floor(extract(epoch FROM sr.record_time) / :bucketSize) * :bucketSize) AS bucketTime,
-              AVG(CAST(sd.value AS double precision)) AS avgValue
+              AVG(sd.numeric_value) AS avgValue
             FROM sensor_data sd
             JOIN sensor_record sr ON sd.record_id = sr.id
         WHERE sr.device_id = :deviceId

--- a/src/test/java/se/hydroleaf/service/RecordServiceSpectralTests.java
+++ b/src/test/java/se/hydroleaf/service/RecordServiceSpectralTests.java
@@ -25,4 +25,44 @@ class RecordServiceSpectralTests {
     private SensorRecordRepository recordRepository;
 
 
+    @Test
+    void spectrumValuesAreStoredAsSeparateRows() {
+        String json = """
+            {
+              "deviceId": "esp-1",
+              "timestamp": "2024-01-01T00:00:00Z",
+              "location": "test",
+              "sensors": [
+                {
+                  "sensorId": "spec1",
+                  "type": "color",
+                  "unit": "count",
+                  "value": {"spectrum": {"445": 10, "480": 20}}
+                }
+              ]
+            }
+            """;
+
+        recordService.saveMessage("growSensors", json);
+
+        List<SensorRecord> records = recordRepository.findAll();
+        assertEquals(1, records.size());
+        List<SensorData> sensors = records.get(0).getSensors();
+        assertEquals(2, sensors.size());
+
+        Set<String> types = sensors.stream().map(SensorData::getType).collect(Collectors.toSet());
+        assertTrue(types.contains("color_445nm"));
+        assertTrue(types.contains("color_480nm"));
+
+        for (SensorData sd : sensors) {
+            if ("color_445nm".equals(sd.getType())) {
+                assertEquals(10.0, sd.getNumericValue());
+            }
+            if ("color_480nm".equals(sd.getType())) {
+                assertEquals(20.0, sd.getNumericValue());
+            }
+            assertNull(sd.getSensorValue());
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- map `numeric_value` column directly in `SensorData`
- aggregate sensor data using `numeric_value`
- parse spectrum data in `RecordService` and store each wavelength as its own `SensorData` entry
- add test verifying spectral values are stored separately

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/... because internet is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6884c56b9d148328bd597df9b4debe5b