### PR TITLE
Add local profile for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,13 @@ docker run -p 8080:8080 \
 ## REST Endpoints
 
 * `GET /api/sensors/history/aggregated` - groups values by sensor and lists timestamp/value pairs. Results are automatically downsampled to roughly 300 points based on the requested time range, discarding zero values when possible.
+
+## Local development
+
+A separate `application-local.yaml` allows running the service with a Postgres instance on your machine. Start the app using the `local` profile:
+
+```bash
+SPRING_PROFILES_ACTIVE=local ./mvnw spring-boot:run
+```
+
+Modify the values in `src/main/resources/application-local.yaml` if your database settings differ.

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,20 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:postgresql://localhost:5432/nft
+    username: postgres
+    password: postgres
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+mqtt:
+  broker: ${MQTT_BROKER:tcp://localhost:1883}
+  enabled: true
+server:
+  ssl:
+    enabled: false


### PR DESCRIPTION
## Summary
- add `application-local.yaml` to configure local database credentials
- document how to run the service with the `local` profile

## Testing
- `mvn -q test` *(fails: non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6884e9c194448328880eed74c2ff46df