### PR TITLE
Fix Instant parsing for query parameters

### DIFF
--- a/src/main/java/se/hydroleaf/controller/SensorRecordController.java
+++ b/src/main/java/se/hydroleaf/controller/SensorRecordController.java
@@ -1,6 +1,5 @@
 package se.hydroleaf.controller;
 
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -9,6 +8,10 @@ import se.hydroleaf.dto.AggregatedHistoryResponse;
 import se.hydroleaf.service.RecordService;
 
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
 @RestController
 @RequestMapping("/api/sensors")
 public class SensorRecordController {
@@ -22,8 +25,22 @@ public class SensorRecordController {
     @GetMapping("/history/aggregated")
     public AggregatedHistoryResponse getHistoryAggregated(
             @RequestParam("espId") String espId,
-            @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
-            @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
-        return recordService.getAggregatedRecords(espId, from, to);
+            @RequestParam("from") String from,
+            @RequestParam("to") String to) {
+        Instant fromInst = parseInstant(from);
+        Instant toInst = parseInstant(to);
+        return recordService.getAggregatedRecords(espId, fromInst, toInst);
+    }
+
+    private Instant parseInstant(String s) {
+        try {
+            return Instant.parse(s);
+        } catch (DateTimeParseException e) {
+            DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+                    .appendPattern("yyyy-MM-dd'T'H:mm:ss")
+                    .appendOffsetId()
+                    .toFormatter();
+            return OffsetDateTime.parse(s, formatter).toInstant();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- relax date parsing in `SensorRecordController`

## Testing
- `mvnw test` *(fails: repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6887492a4fe48328bf1673bbb45a34bf