### PR TITLE
Fix storing MQTT records with flexible timestamps

### DIFF
--- a/src/main/java/se/hydroleaf/controller/SensorRecordController.java
+++ b/src/main/java/se/hydroleaf/controller/SensorRecordController.java
@@ -1,12 +1,12 @@
 package se.hydroleaf.controller;
 
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import se.hydroleaf.dto.AggregatedHistoryResponse;
 import se.hydroleaf.service.RecordService;
+import se.hydroleaf.util.InstantUtil;
 
 import java.time.Instant;
 @RestController
@@ -22,8 +22,10 @@ public class SensorRecordController {
     @GetMapping("/history/aggregated")
     public AggregatedHistoryResponse getHistoryAggregated(
             @RequestParam("espId") String espId,
-            @RequestParam("from") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant from,
-            @RequestParam("to") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant to) {
-        return recordService.getAggregatedRecords(espId, from, to);
+            @RequestParam("from") String from,
+            @RequestParam("to") String to) {
+        Instant fromInst = InstantUtil.parse(from);
+        Instant toInst = InstantUtil.parse(to);
+        return recordService.getAggregatedRecords(espId, fromInst, toInst);
     }
 }

--- a/src/main/java/se/hydroleaf/service/RecordService.java
+++ b/src/main/java/se/hydroleaf/service/RecordService.java
@@ -10,6 +10,7 @@ import se.hydroleaf.dto.AggregatedHistoryResponse;
 import se.hydroleaf.dto.AggregatedSensorData;
 import se.hydroleaf.model.*;
 import se.hydroleaf.repository.*;
+import se.hydroleaf.util.InstantUtil;
 
 import java.time.Instant;
 import java.util.*;
@@ -60,7 +61,7 @@ public class RecordService {
 
             // Create sensor record
             SensorRecord record = new SensorRecord();
-            record.setTimestamp(Instant.parse(node.path("timestamp").asText()));
+            record.setTimestamp(InstantUtil.parse(node.path("timestamp").asText()));
             record.setDevice(device);
 
             // Parse sensors

--- a/src/main/java/se/hydroleaf/util/InstantUtil.java
+++ b/src/main/java/se/hydroleaf/util/InstantUtil.java
@@ -1,0 +1,24 @@
+package se.hydroleaf.util;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+
+public final class InstantUtil {
+    private InstantUtil() {}
+
+    private static final DateTimeFormatter FLEXIBLE_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'H:mm:ss")
+            .appendOffsetId()
+            .toFormatter();
+
+    public static Instant parse(String value) {
+        try {
+            return Instant.parse(value);
+        } catch (DateTimeParseException e) {
+            return OffsetDateTime.parse(value, FLEXIBLE_FORMATTER).toInstant();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- centralize Instant parsing logic
- use flexible Instant parsing in `SensorRecordController`
- parse incoming MQTT timestamps using the same logic

## Testing
- `./mvnw test` *(fails: repo.maven.apache.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6887492a4fe48328bf1673bbb45a34bf