### PR TITLE
Fix recursive toString in entity models

### DIFF
--- a/src/main/java/se/hydroleaf/model/Device.java
+++ b/src/main/java/se/hydroleaf/model/Device.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
@@ -20,11 +21,13 @@ public class Device {
     private String location;
 
     // Each device belongs to one device group
+    @ToString.Exclude
     @ManyToOne
     @JoinColumn(name = "group_id")
     private DeviceGroup group;
 
     // One device can have many sensor records
+    @ToString.Exclude
     @OneToMany(mappedBy = "device", cascade = CascadeType.ALL)
     private List<SensorRecord> sensorRecords;
 }

--- a/src/main/java/se/hydroleaf/model/DeviceGroup.java
+++ b/src/main/java/se/hydroleaf/model/DeviceGroup.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
@@ -22,6 +23,7 @@ public class DeviceGroup {
     private String mqttTopic;
 
     // One device group contains many devices
+    @ToString.Exclude
     @OneToMany(mappedBy = "group")
     private List<Device> devices;
 }

--- a/src/main/java/se/hydroleaf/model/SensorData.java
+++ b/src/main/java/se/hydroleaf/model/SensorData.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 import lombok.NoArgsConstructor;
 
 
@@ -25,6 +26,7 @@ public class SensorData {
     @Column(name = "data")
     private Double data;
 
+    @ToString.Exclude
     @ManyToOne
     @JoinColumn(name = "record_id")
     private SensorRecord record;

--- a/src/main/java/se/hydroleaf/model/SensorHealthItem.java
+++ b/src/main/java/se/hydroleaf/model/SensorHealthItem.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -20,6 +21,7 @@ public class SensorHealthItem {
     private String sensorType;  // e.g. "sht3x", "veml7700"
     private Boolean status;
 
+    @ToString.Exclude
     @ManyToOne
     @JoinColumn(name = "record_id")
     private SensorRecord record;

--- a/src/main/java/se/hydroleaf/model/SensorRecord.java
+++ b/src/main/java/se/hydroleaf/model/SensorRecord.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
@@ -24,15 +25,18 @@ public class SensorRecord {
     private Instant timestamp;
 
     // Each record belongs to one device
+    @ToString.Exclude
     @ManyToOne
     @JoinColumn(name = "device_id")
     private Device device;
 
     // One record contains many sensor data items
+    @ToString.Exclude
     @OneToMany(mappedBy = "record", cascade = CascadeType.ALL)
     private List<SensorData> sensors;
 
     // One SensorRecord contains many health
+    @ToString.Exclude
     @OneToMany(mappedBy = "record", cascade = CascadeType.ALL)
     private List<SensorHealthItem> health;
 }


### PR DESCRIPTION
## Summary
- prevent Lombok-generated `toString` from traversing entity relations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68875d0176208328ad25fae2c57208aa