### PR TITLE
Add water tank tests and document sensor JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,38 @@
 
 This project is a Spring Boot application that connects to an MQTT broker and stores incoming messages in a PostgreSQL database. It also forwards the data to WebSocket subscribers.
 
+## MQTT Message Format
+
+Sensor data is published as JSON where each entry in the `sensors` array includes both a `sensorName` and a `valueType`. Examples:
+
+### Grow sensors
+
+```json
+{
+  "deviceId": "esp-1",
+  "timestamp": "2024-01-01T00:00:00Z",
+  "location": "test",
+  "sensors": [
+    { "sensorName": "spec1", "valueType": "445nm", "unit": "count", "value": 10 },
+    { "sensorName": "spec1", "valueType": "480nm", "unit": "count", "value": 20 }
+  ]
+}
+```
+
+### Water tank
+
+```json
+{
+  "deviceId": "tank-1",
+  "timestamp": "2024-01-01T00:00:00Z",
+  "location": "test",
+  "sensors": [
+    { "sensorName": "tank1", "valueType": "level", "unit": "percent", "value": 70 },
+    { "sensorName": "tank1", "valueType": "temperature", "unit": "C", "value": 22 }
+  ]
+}
+```
+
 ## Building and running with Docker
 
 1. Build the Docker image:


### PR DESCRIPTION
## Summary
- build sensor JSON in tests using sensorName and valueType placeholders
- cover `waterTank` topic with new persistence test
- document MQTT sensor message format with grow sensor and water tank examples

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6891380d230c8328a901ae248dac024b