### PR TITLE
fix: avoid reserved column name for sensor values

### DIFF
--- a/src/main/java/se/hydroleaf/model/SensorData.java
+++ b/src/main/java/se/hydroleaf/model/SensorData.java
@@ -27,7 +27,10 @@ public class SensorData {
 
     private String unit;
 
-    @Column(name = "value")
+    // 'value' is a reserved keyword in some databases (e.g. H2).
+    // Map the Java field 'value' to a column with a safer name to
+    // ensure schema generation works across different database vendors.
+    @Column(name = "sensor_value")
     private Double value;
 
     @Column(name = "source")

--- a/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
@@ -20,7 +20,7 @@ public interface SensorDataRepository extends JpaRepository<SensorData, Long> {
               sd.value_type AS valueType,
               sd.unit AS unit,
               to_timestamp(floor(extract(epoch FROM sr.record_time) / :bucketSize) * :bucketSize) AS bucketTime,
-              AVG(sd.value) AS avgValue
+              AVG(sd.sensor_value) AS avgValue
             FROM sensor_data sd
             JOIN sensor_record sr ON sd.record_id = sr.id
         WHERE sr.device_id = :deviceId


### PR DESCRIPTION
## Summary
- map SensorData `value` field to `sensor_value` column to avoid using reserved keyword
- update aggregation query to reference new column

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68913be86328832899106a90b0ee2973