### PR TITLE
feat: add SPA fallback routing

### DIFF
--- a/src/main/java/se/hydroleaf/WebConfig.java
+++ b/src/main/java/se/hydroleaf/WebConfig.java
@@ -2,6 +2,7 @@ package se.hydroleaf;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -14,5 +15,13 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addViewController("/{path:^(?!api$)[^\\.]*}")
+                .setViewName("forward:/index.html");
+        registry.addViewController("/{path:^(?!api$)[^\\.]*}/**/{subpath:[^\\.]*}")
+                .setViewName("forward:/index.html");
     }
 }


### PR DESCRIPTION
## Summary
- forward non-API, non-static routes to index.html for React SPA support

## Testing
- `./mvnw -q test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68986ccf98d88328bf96aff8b6e9cfd9