### PR TITLE
Persist oxygen pump actuator messages

### DIFF
--- a/src/main/java/se/hydroleaf/model/OxygenPumpStatus.java
+++ b/src/main/java/se/hydroleaf/model/OxygenPumpStatus.java
@@ -1,0 +1,31 @@
+package se.hydroleaf.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "oxygen_pump_status")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class OxygenPumpStatus {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "status_time")
+    private Instant timestamp;
+
+    private Boolean status;
+
+    private String system;
+
+    private String layer;
+}

--- a/src/main/java/se/hydroleaf/repository/OxygenPumpStatusRepository.java
+++ b/src/main/java/se/hydroleaf/repository/OxygenPumpStatusRepository.java
@@ -1,0 +1,9 @@
+package se.hydroleaf.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import se.hydroleaf.model.OxygenPumpStatus;
+
+@Repository
+public interface OxygenPumpStatusRepository extends JpaRepository<OxygenPumpStatus, Long> {
+}

--- a/src/main/java/se/hydroleaf/service/ActuatorService.java
+++ b/src/main/java/se/hydroleaf/service/ActuatorService.java
@@ -1,0 +1,40 @@
+package se.hydroleaf.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import se.hydroleaf.model.OxygenPumpStatus;
+import se.hydroleaf.repository.OxygenPumpStatusRepository;
+import se.hydroleaf.util.InstantUtil;
+
+@Service
+public class ActuatorService {
+
+    private final OxygenPumpStatusRepository oxygenPumpStatusRepository;
+    private final ObjectMapper objectMapper;
+
+    public ActuatorService(OxygenPumpStatusRepository oxygenPumpStatusRepository, ObjectMapper objectMapper) {
+        this.oxygenPumpStatusRepository = oxygenPumpStatusRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public void saveOxygenPumpStatus(String json) {
+        try {
+            JsonNode node = objectMapper.readTree(json);
+            OxygenPumpStatus status = new OxygenPumpStatus();
+            status.setTimestamp(InstantUtil.parse(node.path("timestamp").asText()));
+            status.setStatus(node.path("status").asBoolean());
+            if (!node.path("system").isMissingNode()) {
+                status.setSystem(node.path("system").asText());
+            }
+            if (!node.path("layer").isMissingNode()) {
+                status.setLayer(node.path("layer").asText());
+            }
+            oxygenPumpStatusRepository.save(status);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse and save oxygen pump status", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `OxygenPumpStatus` entity for storing actuator state
- parse and save oxygen pump statuses via new `ActuatorService`
- route `actuator/oxygenPum` MQTT topic to actuator persistence

## Testing
- `./mvnw -e test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_6898c4e25314832892f7e5aa58c2ea41