### PR TITLE
Add average status query and endpoint

### DIFF
--- a/src/main/java/se/hydroleaf/controller/StatusController.java
+++ b/src/main/java/se/hydroleaf/controller/StatusController.java
@@ -1,0 +1,27 @@
+package se.hydroleaf.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import se.hydroleaf.dto.StatusAverageResponse;
+import se.hydroleaf.service.StatusService;
+
+@RestController
+@RequestMapping("/api/status")
+public class StatusController {
+
+    private final StatusService statusService;
+
+    public StatusController(StatusService statusService) {
+        this.statusService = statusService;
+    }
+
+    @GetMapping("/average")
+    public StatusAverageResponse getAverage(
+            @RequestParam String system,
+            @RequestParam String layer,
+            @RequestParam String sensorType) {
+        return statusService.getAverage(system, layer, sensorType);
+    }
+}

--- a/src/main/java/se/hydroleaf/dto/StatusAverageResponse.java
+++ b/src/main/java/se/hydroleaf/dto/StatusAverageResponse.java
@@ -1,0 +1,3 @@
+package se.hydroleaf.dto;
+
+public record StatusAverageResponse(Double average, long deviceCount) {}

--- a/src/main/java/se/hydroleaf/repository/AverageResult.java
+++ b/src/main/java/se/hydroleaf/repository/AverageResult.java
@@ -1,0 +1,6 @@
+package se.hydroleaf.repository;
+
+public interface AverageResult {
+    Double getAverage();
+    Long getCount();
+}

--- a/src/main/java/se/hydroleaf/repository/OxygenPumpStatusRepository.java
+++ b/src/main/java/se/hydroleaf/repository/OxygenPumpStatusRepository.java
@@ -1,9 +1,26 @@
 package se.hydroleaf.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import se.hydroleaf.model.OxygenPumpStatus;
 
 @Repository
 public interface OxygenPumpStatusRepository extends JpaRepository<OxygenPumpStatus, Long> {
+
+    @Query(value = """
+            SELECT AVG(val) AS average, COUNT(*) AS count
+            FROM (
+                SELECT (CASE WHEN status THEN 1 ELSE 0 END) AS val
+                FROM oxygen_pump_status
+                WHERE system = :system AND layer = :layer
+                ORDER BY status_time DESC
+                LIMIT 1
+            ) latest
+            """, nativeQuery = true)
+    AverageResult getLatestAverage(
+            @Param("system") String system,
+            @Param("layer") String layer
+    );
 }

--- a/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
@@ -34,4 +34,23 @@ public interface SensorDataRepository extends JpaRepository<SensorData, Long> {
             @Param("to") Instant to,
             @Param("bucketSize") long bucketSizeInSeconds
     );
+
+    @Query(value = """
+            SELECT AVG(latest_value) AS average, COUNT(*) AS count
+            FROM (
+                SELECT DISTINCT ON (d.id) sd.sensor_value AS latest_value
+                FROM device d
+                JOIN sensor_record sr ON sr.device_id = d.id
+                JOIN sensor_data sd ON sd.record_id = sr.id
+                WHERE d.system = :system
+                  AND d.location = :layer
+                  AND sd.value_type = :sensorType
+                ORDER BY d.id, sr.record_time DESC
+            ) latest
+            """, nativeQuery = true)
+    AverageResult getLatestAverage(
+            @Param("system") String system,
+            @Param("layer") String layer,
+            @Param("sensorType") String sensorType
+    );
 }

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -1,0 +1,40 @@
+package se.hydroleaf.service;
+
+import org.springframework.stereotype.Service;
+import se.hydroleaf.dto.StatusAverageResponse;
+import se.hydroleaf.repository.AverageResult;
+import se.hydroleaf.repository.OxygenPumpStatusRepository;
+import se.hydroleaf.repository.SensorDataRepository;
+
+@Service
+public class StatusService {
+
+    private final SensorDataRepository sensorDataRepository;
+    private final OxygenPumpStatusRepository oxygenPumpStatusRepository;
+
+    public StatusService(SensorDataRepository sensorDataRepository,
+                         OxygenPumpStatusRepository oxygenPumpStatusRepository) {
+        this.sensorDataRepository = sensorDataRepository;
+        this.oxygenPumpStatusRepository = oxygenPumpStatusRepository;
+    }
+
+    public StatusAverageResponse getAverage(String system, String layer, String sensorType) {
+        AverageResult result;
+        if (isOxygenPump(sensorType)) {
+            result = oxygenPumpStatusRepository.getLatestAverage(system, layer);
+        } else {
+            result = sensorDataRepository.getLatestAverage(system, layer, sensorType);
+        }
+        Double avg = result != null ? result.getAverage() : null;
+        long count = result != null && result.getCount() != null ? result.getCount() : 0L;
+        return new StatusAverageResponse(avg, count);
+    }
+
+    private boolean isOxygenPump(String sensorType) {
+        if (sensorType == null) {
+            return false;
+        }
+        String type = sensorType.toLowerCase();
+        return type.equals("oxygenpump") || type.equals("oxygen-pump") || type.equals("oxygenpumpstatus");
+    }
+}


### PR DESCRIPTION
## Summary
- add repository methods to fetch latest sensor and oxygen pump readings per device and compute averages
- implement StatusService and DTO to return average value and contributing device count
- expose GET `/api/status/average` for querying sensor and pump status averages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6898c74460f88328a36da2d66c72833a