### PR TITLE
Add all-sensor status average endpoints

### DIFF
--- a/src/main/java/se/hydroleaf/controller/StatusController.java
+++ b/src/main/java/se/hydroleaf/controller/StatusController.java
@@ -1,9 +1,10 @@
 package se.hydroleaf.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import se.hydroleaf.dto.StatusAllAverageResponse;
 import se.hydroleaf.dto.StatusAverageResponse;
 import se.hydroleaf.service.StatusService;
 
@@ -17,11 +18,18 @@ public class StatusController {
         this.statusService = statusService;
     }
 
-    @GetMapping("/average")
+    @GetMapping("/{system}/{layer}/{sensorType}/average")
     public StatusAverageResponse getAverage(
-            @RequestParam String system,
-            @RequestParam String layer,
-            @RequestParam String sensorType) {
+            @PathVariable String system,
+            @PathVariable String layer,
+            @PathVariable String sensorType) {
         return statusService.getAverage(system, layer, sensorType);
+    }
+
+    @GetMapping("/{system}/{layer}/all/average")
+    public StatusAllAverageResponse getAllAverages(
+            @PathVariable String system,
+            @PathVariable String layer) {
+        return statusService.getAllAverages(system, layer);
     }
 }

--- a/src/main/java/se/hydroleaf/dto/StatusAllAverageResponse.java
+++ b/src/main/java/se/hydroleaf/dto/StatusAllAverageResponse.java
@@ -1,0 +1,11 @@
+package se.hydroleaf.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record StatusAllAverageResponse(
+        StatusAverageResponse lux,
+        StatusAverageResponse humidity,
+        StatusAverageResponse temperature,
+        @JsonProperty("do") StatusAverageResponse dissolvedOxygen,
+        StatusAverageResponse airpump
+) {}

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -1,10 +1,15 @@
 package se.hydroleaf.service;
 
 import org.springframework.stereotype.Service;
+import se.hydroleaf.dto.StatusAllAverageResponse;
 import se.hydroleaf.dto.StatusAverageResponse;
 import se.hydroleaf.repository.AverageResult;
 import se.hydroleaf.repository.OxygenPumpStatusRepository;
 import se.hydroleaf.repository.SensorDataRepository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Service
 public class StatusService {
@@ -30,11 +35,27 @@ public class StatusService {
         return new StatusAverageResponse(avg, count);
     }
 
+    public StatusAllAverageResponse getAllAverages(String system, String layer) {
+        List<String> sensorTypes = List.of("lux", "humidity", "temperature", "do", "airpump");
+        Map<String, StatusAverageResponse> responses = new HashMap<>();
+        for (String type : sensorTypes) {
+            responses.put(type, getAverage(system, layer, type));
+        }
+        return new StatusAllAverageResponse(
+                responses.get("lux"),
+                responses.get("humidity"),
+                responses.get("temperature"),
+                responses.get("do"),
+                responses.get("airpump")
+        );
+    }
+
     private boolean isOxygenPump(String sensorType) {
         if (sensorType == null) {
             return false;
         }
         String type = sensorType.toLowerCase();
-        return type.equals("oxygenpump") || type.equals("oxygen-pump") || type.equals("oxygenpumpstatus");
+        return type.equals("oxygenpump") || type.equals("oxygen-pump") ||
+                type.equals("oxygenpumpstatus") || type.equals("airpump");
     }
 }

--- a/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
@@ -1,0 +1,59 @@
+package se.hydroleaf.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import se.hydroleaf.dto.StatusAllAverageResponse;
+import se.hydroleaf.dto.StatusAverageResponse;
+import se.hydroleaf.service.StatusService;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class StatusControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StatusService statusService;
+
+    @Test
+    void getAverageEndpointReturnsData() throws Exception {
+        when(statusService.getAverage("sys", "layer", "lux"))
+                .thenReturn(new StatusAverageResponse(12.5, 3L));
+
+        mockMvc.perform(get("/api/status/sys/layer/lux/average"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.average").value(12.5))
+                .andExpect(jsonPath("$.deviceCount").value(3));
+    }
+
+    @Test
+    void getAllAveragesEndpointReturnsData() throws Exception {
+        StatusAllAverageResponse response = new StatusAllAverageResponse(
+                new StatusAverageResponse(1.0,1L),
+                new StatusAverageResponse(2.0,2L),
+                new StatusAverageResponse(3.0,3L),
+                new StatusAverageResponse(4.0,4L),
+                new StatusAverageResponse(5.0,5L)
+        );
+        when(statusService.getAllAverages("sys", "layer")).thenReturn(response);
+
+        mockMvc.perform(get("/api/status/sys/layer/all/average"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lux.average").value(1.0))
+                .andExpect(jsonPath("$.humidity.average").value(2.0))
+                .andExpect(jsonPath("$.temperature.average").value(3.0))
+                .andExpect(jsonPath("$.do.average").value(4.0))
+                .andExpect(jsonPath("$.airpump.average").value(5.0));
+    }
+}

--- a/src/test/java/se/hydroleaf/service/StatusServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/StatusServiceTest.java
@@ -1,0 +1,91 @@
+package se.hydroleaf.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.hydroleaf.dto.StatusAllAverageResponse;
+import se.hydroleaf.dto.StatusAverageResponse;
+import se.hydroleaf.repository.AverageResult;
+import se.hydroleaf.repository.OxygenPumpStatusRepository;
+import se.hydroleaf.repository.SensorDataRepository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StatusServiceTest {
+
+    @Mock
+    private SensorDataRepository sensorDataRepository;
+
+    @Mock
+    private OxygenPumpStatusRepository oxygenPumpStatusRepository;
+
+    @InjectMocks
+    private StatusService statusService;
+
+    @Test
+    void getAverageUsesSensorDataRepository() {
+        AverageResult avg = simpleResult(10.0, 3L);
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "lux"))
+                .thenReturn(avg);
+
+        StatusAverageResponse response = statusService.getAverage("sys", "layer", "lux");
+        assertEquals(10.0, response.average());
+        assertEquals(3L, response.deviceCount());
+        verify(sensorDataRepository).getLatestAverage("sys", "layer", "lux");
+        verifyNoInteractions(oxygenPumpStatusRepository);
+    }
+
+    @Test
+    void getAverageUsesOxygenPumpRepositoryForAirpump() {
+        AverageResult avg = simpleResult(1.5, 2L);
+        when(oxygenPumpStatusRepository.getLatestAverage("sys", "layer"))
+                .thenReturn(avg);
+
+        StatusAverageResponse response = statusService.getAverage("sys", "layer", "airpump");
+        assertEquals(1.5, response.average());
+        assertEquals(2L, response.deviceCount());
+        verify(oxygenPumpStatusRepository).getLatestAverage("sys", "layer");
+        verifyNoMoreInteractions(oxygenPumpStatusRepository);
+        verifyNoInteractions(sensorDataRepository);
+    }
+
+    @Test
+    void getAllAveragesAggregatesAllSensorTypes() {
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "lux"))
+                .thenReturn(simpleResult(1.0, 1L));
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "humidity"))
+                .thenReturn(simpleResult(2.0, 2L));
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "temperature"))
+                .thenReturn(simpleResult(3.0, 3L));
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "do"))
+                .thenReturn(simpleResult(4.0, 4L));
+        when(oxygenPumpStatusRepository.getLatestAverage("sys", "layer"))
+                .thenReturn(simpleResult(5.0, 5L));
+
+        StatusAllAverageResponse response = statusService.getAllAverages("sys", "layer");
+
+        assertEquals(1.0, response.lux().average());
+        assertEquals(2.0, response.humidity().average());
+        assertEquals(3.0, response.temperature().average());
+        assertEquals(4.0, response.dissolvedOxygen().average());
+        assertEquals(5.0, response.airpump().average());
+    }
+
+    private AverageResult simpleResult(Double avg, Long count) {
+        return new AverageResult() {
+            @Override
+            public Double getAverage() {
+                return avg;
+            }
+
+            @Override
+            public Long getCount() {
+                return count;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- refactor status controller to use path variables and add `/all/average` endpoint
- extend status service with all-averages computation and airpump handling
- introduce `StatusAllAverageResponse` DTO and new unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM – network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898d238dd388328a4a6703e697e3fc5