### PR TITLE
Send live status averages over WebSocket

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttService.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttService.java
@@ -14,6 +14,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import se.hydroleaf.service.ActuatorService;
 import se.hydroleaf.service.RecordService;
+import se.hydroleaf.service.StatusService;
 
 @Slf4j
 @Service
@@ -23,6 +24,7 @@ public class MqttService implements MqttCallback {
     private final RecordService recordService;
     private final ActuatorService actuatorService;
     private final SimpMessagingTemplate messagingTemplate;
+    private final StatusService statusService;
 
     private final ConcurrentHashMap<String, Instant> lastSaveTimestamps = new ConcurrentHashMap<>();
 
@@ -31,10 +33,12 @@ public class MqttService implements MqttCallback {
 
     private IMqttClient client;
 
-    public MqttService(RecordService recordService, ActuatorService actuatorService, SimpMessagingTemplate messagingTemplate) {
+    public MqttService(RecordService recordService, ActuatorService actuatorService,
+                       SimpMessagingTemplate messagingTemplate, StatusService statusService) {
         this.recordService = recordService;
         this.actuatorService = actuatorService;
         this.messagingTemplate = messagingTemplate;
+        this.statusService = statusService;
     }
 
     @PostConstruct
@@ -99,6 +103,7 @@ public class MqttService implements MqttCallback {
             lastSaveTimestamps.put(topic, now);
         }
         messagingTemplate.convertAndSend("/topic/" + topic, payload);
+        messagingTemplate.convertAndSend("/topic/live_now", statusService.getAllAverages("s01", "l01"));
     }
 
     @Override

--- a/src/test/java/se/hydroleaf/service/StatusServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/StatusServiceTest.java
@@ -36,8 +36,6 @@ class StatusServiceTest {
         assertEquals(10.0, response.average());
         assertEquals(3L, response.deviceCount());
         verify(sensorDataRepository).getLatestAverage("Sys", "Layer", "lux");
-        when(sensorDataRepository.getLatestAverage("sys", "layer", "lux"))
-                .thenReturn(avg);
         verifyNoInteractions(oxygenPumpStatusRepository);
     }
 


### PR DESCRIPTION
## Summary
- push computed average status data to `/topic/live_now` on each MQTT message
- wire `StatusService` into `MqttService` to provide real-time aggregates

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689909bb6c008328987939471644b2b1