### PR TITLE
Fix oxygen pump status query returning null averages

### DIFF
--- a/src/main/java/se/hydroleaf/repository/OxygenPumpStatusRepository.java
+++ b/src/main/java/se/hydroleaf/repository/OxygenPumpStatusRepository.java
@@ -10,7 +10,8 @@ import se.hydroleaf.model.OxygenPumpStatus;
 public interface OxygenPumpStatusRepository extends JpaRepository<OxygenPumpStatus, Long> {
 
     @Query(value = """
-            SELECT status
+            SELECT status::double precision AS average,
+                   1 AS count
             FROM oxygen_pump_status
             WHERE LOWER(system)= LOWER(:system) AND LOWER(layer)= LOWER(:layer)
             ORDER BY status_time DESC


### PR DESCRIPTION
## Summary
- ensure oxygen pump status query returns `average` and `count` fields so live_now data isn't null

## Testing
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_6899263a38a08328a9bade30d8e54058