### PR TITLE
feat: serve placeholder index page

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>HydroLeaf</title>
+</head>
+<body>
+  <h1>HydroLeaf Application</h1>
+  <p>This is a placeholder page served by the backend.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add static placeholder `index.html` so browser routing avoids 404

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch maven binary)*

------
https://chatgpt.com/codex/tasks/task_e_689a4580c09083288b8c819a88e36d75