### PR TITLE
Update oxygen pump status to overwrite previous entry

### DIFF
--- a/src/main/java/se/hydroleaf/repository/OxygenPumpStatusRepository.java
+++ b/src/main/java/se/hydroleaf/repository/OxygenPumpStatusRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import se.hydroleaf.model.OxygenPumpStatus;
 
+import java.util.Optional;
+
 @Repository
 public interface OxygenPumpStatusRepository extends JpaRepository<OxygenPumpStatus, Long> {
 
@@ -20,4 +22,6 @@ public interface OxygenPumpStatusRepository extends JpaRepository<OxygenPumpStat
             @Param("system") String system,
             @Param("layer") String layer
     );
+
+    Optional<OxygenPumpStatus> findTopByOrderByIdAsc();
 }

--- a/src/main/java/se/hydroleaf/service/ActuatorService.java
+++ b/src/main/java/se/hydroleaf/service/ActuatorService.java
@@ -23,7 +23,8 @@ public class ActuatorService {
     public void saveOxygenPumpStatus(String json) {
         try {
             JsonNode node = objectMapper.readTree(json);
-            OxygenPumpStatus status = new OxygenPumpStatus();
+            OxygenPumpStatus status = oxygenPumpStatusRepository.findTopByOrderByIdAsc()
+                    .orElseGet(OxygenPumpStatus::new);
             status.setTimestamp(InstantUtil.parse(node.path("timestamp").asText()));
             status.setStatus(node.path("status").asBoolean());
             if (!node.path("system").isMissingNode()) {

--- a/src/test/java/se/hydroleaf/service/ActuatorServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/ActuatorServiceTest.java
@@ -1,0 +1,63 @@
+package se.hydroleaf.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.hydroleaf.model.OxygenPumpStatus;
+import se.hydroleaf.repository.OxygenPumpStatusRepository;
+import se.hydroleaf.util.InstantUtil;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ActuatorServiceTest {
+
+    @Mock
+    private OxygenPumpStatusRepository oxygenPumpStatusRepository;
+
+    private ActuatorService actuatorService;
+
+    @BeforeEach
+    void setUp() {
+        actuatorService = new ActuatorService(oxygenPumpStatusRepository, new ObjectMapper());
+    }
+
+    @Test
+    void updatesExistingStatusWhenPresent() {
+        OxygenPumpStatus existing = new OxygenPumpStatus();
+        existing.setId(1L);
+        when(oxygenPumpStatusRepository.findTopByOrderByIdAsc()).thenReturn(Optional.of(existing));
+
+        String json = "{\"timestamp\":\"2023-01-01T00:00:00Z\",\"status\":true}";
+        actuatorService.saveOxygenPumpStatus(json);
+
+        ArgumentCaptor<OxygenPumpStatus> captor = ArgumentCaptor.forClass(OxygenPumpStatus.class);
+        verify(oxygenPumpStatusRepository).save(captor.capture());
+        OxygenPumpStatus saved = captor.getValue();
+        assertSame(existing, saved);
+        assertEquals(InstantUtil.parse("2023-01-01T00:00:00Z"), saved.getTimestamp());
+        assertTrue(saved.getStatus());
+    }
+
+    @Test
+    void createsNewStatusWhenNoneExists() {
+        when(oxygenPumpStatusRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+
+        String json = "{\"timestamp\":\"2023-01-01T00:00:00Z\",\"status\":false}";
+        actuatorService.saveOxygenPumpStatus(json);
+
+        ArgumentCaptor<OxygenPumpStatus> captor = ArgumentCaptor.forClass(OxygenPumpStatus.class);
+        verify(oxygenPumpStatusRepository).save(captor.capture());
+        OxygenPumpStatus saved = captor.getValue();
+        assertNull(saved.getId());
+        assertEquals(InstantUtil.parse("2023-01-01T00:00:00Z"), saved.getTimestamp());
+        assertFalse(saved.getStatus());
+    }
+}


### PR DESCRIPTION
## Summary
- update `ActuatorService` to overwrite the existing oxygen pump status instead of appending new rows
- add repository helper to fetch the current status entry
- cover new behavior with unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a5c2a8d608328b921e662b4c940a8