### PR TITLE
Handle numeric string oxygen pump status values

### DIFF
--- a/src/main/java/se/hydroleaf/service/ActuatorService.java
+++ b/src/main/java/se/hydroleaf/service/ActuatorService.java
@@ -26,7 +26,10 @@ public class ActuatorService {
             OxygenPumpStatus status = oxygenPumpStatusRepository.findTopByOrderByIdAsc()
                     .orElseGet(OxygenPumpStatus::new);
             status.setTimestamp(InstantUtil.parse(node.path("timestamp").asText()));
-            status.setStatus(node.path("status").asBoolean());
+
+            JsonNode statusNode = node.path("status");
+            boolean parsedStatus = statusNode.asBoolean() || statusNode.asInt() == 1;
+            status.setStatus(parsedStatus);
             if (!node.path("system").isMissingNode()) {
                 status.setSystem(node.path("system").asText());
             }

--- a/src/test/java/se/hydroleaf/service/ActuatorServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/ActuatorServiceTest.java
@@ -60,4 +60,19 @@ class ActuatorServiceTest {
         assertEquals(InstantUtil.parse("2023-01-01T00:00:00Z"), saved.getTimestamp());
         assertFalse(saved.getStatus());
     }
+
+    @Test
+    void parsesNumericStatusValues() {
+        when(oxygenPumpStatusRepository.findTopByOrderByIdAsc()).thenReturn(Optional.empty());
+
+        String json = "{\"timestamp\":\"2023-01-01T00:00:00Z\",\"status\":\"1\"}";
+        actuatorService.saveOxygenPumpStatus(json);
+
+        ArgumentCaptor<OxygenPumpStatus> captor = ArgumentCaptor.forClass(OxygenPumpStatus.class);
+        verify(oxygenPumpStatusRepository).save(captor.capture());
+        OxygenPumpStatus saved = captor.getValue();
+        assertNull(saved.getId());
+        assertEquals(InstantUtil.parse("2023-01-01T00:00:00Z"), saved.getTimestamp());
+        assertTrue(saved.getStatus());
+    }
 }


### PR DESCRIPTION
## Summary
- parse oxygen pump "status" field tolerant of numeric strings
- add test for numeric status parsing

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689a66f03118832880a0bcc230af95e5