### PR TITLE
Broadcast averages for all systems and layers

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttService.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttService.java
@@ -84,8 +84,7 @@ public class MqttService implements MqttCallback {
     public void messageArrived(String topic, MqttMessage message) {
         String payload = new String(message.getPayload());
         messagingTemplate.convertAndSend("/topic/" + topic, payload);
-        statusService.getAllAverages("S01", "L01");
-        messagingTemplate.convertAndSend("/topic/live_now",statusService.getAllAverages("S01", "L01") );
+        messagingTemplate.convertAndSend("/topic/live_now", statusService.getAllSystemLayerAverages());
         Instant now = Instant.now();
         Instant lastSaved = lastSaveTimestamps.get(topic);
         boolean shouldPersist = lastSaved == null || Duration.between(lastSaved, now).getSeconds() >= 5;


### PR DESCRIPTION
## Summary
- gather system+layer averages dynamically using devices
- broadcast combined averages over live_now topic
- add unit test for new system-layer aggregation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cc0939d948328a33956197b3b8e77