### PR TITLE
Move live status broadcasting to scheduled task

### DIFF
--- a/src/main/java/se/hydroleaf/NftBackendApplication.java
+++ b/src/main/java/se/hydroleaf/NftBackendApplication.java
@@ -2,8 +2,10 @@ package se.hydroleaf;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class NftBackendApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
## Summary
- Shift `/topic/live_now` publishing from incoming message handler to a scheduled task
- Enable Spring's scheduling support in main application

## Testing
- `./mvnw test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_689ccba3cdbc832892390954999db3a2