### PR TITLE
Avoid null map keys when sending status updates

### DIFF
--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -67,6 +67,9 @@ public class StatusService {
             if (system == null || system.isBlank()) {
                 continue;
             }
+            if (layer == null || layer.isBlank()) {
+                continue;
+            }
 
             result.computeIfAbsent(system, s -> new HashMap<>())
                     .computeIfAbsent(layer, l -> getAllAverages(system, layer));

--- a/src/test/java/se/hydroleaf/service/StatusServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/StatusServiceTest.java
@@ -113,16 +113,17 @@ class StatusServiceTest {
         Device d1 = Device.builder().id("1").system("").layer("L01").build();
         Device d2 = Device.builder().id("2").system("S01").layer(" ").build();
         Device d3 = Device.builder().id("3").system(null).layer("L02").build();
-        Device valid = Device.builder().id("4").system("S01").layer("L01").build();
-        when(deviceRepository.findAll()).thenReturn(java.util.List.of(d1, d2, d3, valid));
+        Device d4 = Device.builder().id("4").system("S01").layer(null).build();
+        Device valid = Device.builder().id("5").system("S01").layer("L01").build();
+        when(deviceRepository.findAll()).thenReturn(java.util.List.of(d1, d2, d3, d4, valid));
 
         StatusAllAverageResponse r = new StatusAllAverageResponse(null, null, null, null, null);
         doReturn(r).when(statusService).getAllAverages("S01", "L01");
-        doReturn(r).when(statusService).getAllAverages("S01", " ");
 
         var result = statusService.getAllSystemLayerAverages();
 
         assertEquals(1, result.size());
+        assertEquals(1, result.get("S01").size());
         assertEquals(r, result.get("S01").get("L01"));
         verify(statusService).getAllAverages("S01", "L01");
     }


### PR DESCRIPTION
## Summary
- Skip devices with blank or null layers when building the system/layer status map
- Update unit test to cover devices with missing layers

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689cf79b9ad883289e030aff76ccb66b