### PR TITLE
Persist device metadata for incoming sensor messages

### DIFF
--- a/src/main/java/se/hydroleaf/service/RecordService.java
+++ b/src/main/java/se/hydroleaf/service/RecordService.java
@@ -52,12 +52,13 @@ public class RecordService {
                 Device d = new Device();
                 d.setId(deviceId);
                 d.setGroup(group);
-                return deviceRepository.save(d);
+                return d;
             });
 
             device.setLayer(node.path("layer").asText());
             device.setSystem(node.path("system").asText());
             device.setCompositeId(node.path("compositeId").asText());
+            deviceRepository.save(device);
 
             // Create sensor record
             SensorRecord record = new SensorRecord();

--- a/src/test/java/se/hydroleaf/service/RecordServiceDeviceTests.java
+++ b/src/test/java/se/hydroleaf/service/RecordServiceDeviceTests.java
@@ -1,0 +1,56 @@
+package se.hydroleaf.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import se.hydroleaf.model.Device;
+import se.hydroleaf.repository.DeviceRepository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RecordServiceDeviceTests {
+
+    @Autowired
+    private RecordService recordService;
+
+    @Autowired
+    private DeviceRepository deviceRepository;
+
+    @Test
+    @Transactional
+    void deviceSystemAndIdentifiersAreStored() {
+        String json = """
+            {
+              "system": "S02",
+              "deviceId": "G01",
+              "layer": "L02",
+              "compositeId": "S02-L02-G01",
+              "timestamp": "2025-08-13T21:13:31Z",
+              "sensors": [
+                {
+                  "sensorName": "VEML7700",
+                  "valueType": "light",
+                  "value": 19.3536,
+                  "unit": "lux"
+                }
+              ],
+              "health": {
+                "sht3x": false,
+                "veml7700": true,
+                "as7343": false
+              }
+            }
+            """;
+
+        recordService.saveMessage("growSensors", json);
+
+        Device device = deviceRepository.findById("G01").orElseThrow();
+        assertEquals("S02", device.getSystem());
+        assertEquals("L02", device.getLayer());
+        assertEquals("S02-L02-G01", device.getCompositeId());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure device layer, system, and compositeId are saved when processing MQTT messages
- add regression test verifying device metadata persistence

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689d008022808328ab46bfc184e88fae