### PR TITLE
Handle case-insensitive air pump name

### DIFF
--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -43,7 +43,8 @@ public class StatusService {
     }
 
     public StatusAllAverageResponse getAllAverages(String system, String layer) {
-        List<String> sensorTypes = List.of("light", "humidity", "temperature", "dissolvedOxygen", "airpump");
+        String oxygenPumpType = "airPump";
+        List<String> sensorTypes = List.of("light", "humidity", "temperature", "dissolvedOxygen", oxygenPumpType);
         Map<String, StatusAverageResponse> responses = new HashMap<>();
         for (String type : sensorTypes) {
             responses.put(type, getAverage(system, layer, type));
@@ -53,7 +54,7 @@ public class StatusService {
                 responses.get("humidity"),
                 responses.get("temperature"),
                 responses.get("dissolvedOxygen"),
-                responses.get("airpump")
+                responses.get(oxygenPumpType)
         );
     }
 
@@ -81,6 +82,6 @@ public class StatusService {
         if (sensorType == null) {
             return false;
         }
-        return sensorType.equals("airpump");
+        return sensorType.equalsIgnoreCase("airPump") || sensorType.equalsIgnoreCase("airpump");
     }
 }


### PR DESCRIPTION
## Summary
- Allow StatusService to recognize air pump sensor names in any casing
- Use consistent canonical name when aggregating air pump averages

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689dfbb4f5688328a3c0244c9f60ad60