### PR TITLE
Add sensor type column migration and disable ddl auto

### DIFF
--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -9,7 +9,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
 
 mqtt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: false
 mqtt:
   brokerUri: ${MQTT_BROKER:tcp://100.113.16.30:1883}

--- a/src/main/resources/db/migration/V3__add_sensor_type.sql
+++ b/src/main/resources/db/migration/V3__add_sensor_type.sql
@@ -1,0 +1,6 @@
+ALTER TABLE sensor_data ADD COLUMN sensor_type VARCHAR(64);
+
+-- Populate the new column for existing records.
+UPDATE sensor_data SET sensor_type = 'unknown';
+
+ALTER TABLE sensor_data ALTER COLUMN sensor_type SET NOT NULL;


### PR DESCRIPTION
## Summary
- introduce migration adding required `sensor_type` column to `sensor_data`
- turn off Hibernate schema auto-generation to rely on migrations

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e055bb7f88328a99a27431500464c