### PR TITLE
Clean up null sensor_type entries before enforcing constraint

### DIFF
--- a/src/main/resources/db/migration/V3__add_sensor_type.sql
+++ b/src/main/resources/db/migration/V3__add_sensor_type.sql
@@ -1,6 +1,5 @@
-ALTER TABLE sensor_data ADD COLUMN sensor_type VARCHAR(64);
-
--- Populate the new column for existing records.
-UPDATE sensor_data SET sensor_type = 'unknown';
-
-ALTER TABLE sensor_data ALTER COLUMN sensor_type SET NOT NULL;
+-- Populate missing sensor types for existing records before
+-- enforcing the NOT NULL constraint in a later migration.
+UPDATE sensor_data
+SET sensor_type = 'unknown'
+WHERE sensor_type IS NULL;

--- a/src/main/resources/db/migration/V4__enforce_sensor_type_not_null.sql
+++ b/src/main/resources/db/migration/V4__enforce_sensor_type_not_null.sql
@@ -1,0 +1,3 @@
+-- Ensure sensor_type is always provided.
+ALTER TABLE sensor_data
+    ALTER COLUMN sensor_type SET NOT NULL;


### PR DESCRIPTION
## Summary
- Populate missing `sensor_type` values with fallback `'unknown'`
- Enforce `sensor_type` `NOT NULL` constraint after cleanup

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e0d491e2483289118691132830ea6