### PR TITLE
Refactor MQTT message handling

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
@@ -1,0 +1,134 @@
+package se.hydroleaf.mqtt;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import se.hydroleaf.model.Device;
+import se.hydroleaf.model.DeviceGroup;
+import se.hydroleaf.repository.DeviceGroupRepository;
+import se.hydroleaf.repository.DeviceRepository;
+import se.hydroleaf.service.RecordService;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Handles incoming MQTT messages: forwards payload to STOMP,
+ * extracts compositeId, auto-provisions devices/groups and persists data.
+ */
+@Slf4j
+@Component
+public class MqttMessageHandler {
+
+    private final ObjectMapper objectMapper;
+    private final RecordService recordService;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final DeviceRepository deviceRepo;
+    private final DeviceGroupRepository groupRepo;
+
+    @Value("${mqtt.topicPrefix:}")
+    private String topicPrefix;
+
+    private final ConcurrentHashMap<String, Instant> lastSeen = new ConcurrentHashMap<>();
+
+    public MqttMessageHandler(ObjectMapper objectMapper,
+                              RecordService recordService,
+                              SimpMessagingTemplate messagingTemplate,
+                              DeviceRepository deviceRepo,
+                              DeviceGroupRepository groupRepo) {
+        this.objectMapper = objectMapper;
+        this.recordService = recordService;
+        this.messagingTemplate = messagingTemplate;
+        this.deviceRepo = deviceRepo;
+        this.groupRepo = groupRepo;
+    }
+
+    public void handle(String topic, String payload) {
+        messagingTemplate.convertAndSend("/topic/" + topic, payload);
+        try {
+            JsonNode node = objectMapper.readTree(payload);
+
+            String compositeId = readCompositeId(node);
+            if (compositeId == null) {
+                compositeId = deriveCompositeIdFromTopic(topic);
+            }
+            if (compositeId == null || compositeId.isBlank()) {
+                log.warn("MQTT parse/handle failed on topic {}: missing composite_id", topic);
+                return;
+            }
+
+            ensureDevice(compositeId, topic);
+            recordService.saveRecord(compositeId, node);
+            lastSeen.put(compositeId, Instant.now());
+        } catch (Exception ex) {
+            log.error("MQTT handle error for topic {}: {}", topic, ex.getMessage(), ex);
+        }
+    }
+
+    private static String readCompositeId(JsonNode n) {
+        if (n == null) return null;
+        if (n.hasNonNull("composite_id")) return n.get("composite_id").asText();
+        if (n.hasNonNull("compositeId")) return n.get("compositeId").asText();
+        return null;
+    }
+
+    private static final Pattern GROW_PATTERN =
+            Pattern.compile("^growSensors/(S\\d+)/(L\\d+)/([^/]+)$");
+
+    private String deriveCompositeIdFromTopic(String topic) {
+        if (topic == null) return null;
+        Matcher m = GROW_PATTERN.matcher(topic);
+        if (m.find()) {
+            return m.group(1) + "-" + m.group(2) + "-" + m.group(3);
+        }
+        return null;
+    }
+
+    private Device ensureDevice(String compositeId, String topic) {
+        return deviceRepo.findById(compositeId).orElseGet(() -> {
+            Device d = new Device();
+            d.setCompositeId(compositeId);
+
+            String[] parts = compositeId.split("-");
+            if (parts.length >= 3) {
+                d.setSystem(parts[0]);
+                d.setLayer(parts[1]);
+                d.setDeviceId(parts[2]);
+            }
+
+            String grpKey = (topic != null && !topic.isBlank()) ? topic.split("/")[0] : topicPrefix;
+            DeviceGroup g = findOrCreateGroup(grpKey == null ? "default" : grpKey);
+            d.setGroup(g);
+
+            return deviceRepo.save(d);
+        });
+    }
+
+    private DeviceGroup findOrCreateGroup(String mqttKey) {
+        Optional<DeviceGroup> g = groupRepo.findByMqttTopic(mqttKey);
+        if (g.isPresent()) return g.get();
+
+        DeviceGroup ng = new DeviceGroup();
+        ng.setMqttTopic(mqttKey);
+        return groupRepo.save(ng);
+    }
+
+    @Scheduled(fixedDelay = 10000)
+    public void logLaggingDevices() {
+        Instant now = Instant.now();
+        lastSeen.forEach((id, ts) -> {
+            if (Duration.between(ts, now).toSeconds() > 60) {
+                log.debug("Device {} no message for >60s (lastSeen={})", id, ts);
+            }
+        });
+    }
+}
+

--- a/src/main/java/se/hydroleaf/mqtt/MqttService.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttService.java
@@ -1,36 +1,21 @@
 package se.hydroleaf.mqtt;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.paho.client.mqttv3.*;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import se.hydroleaf.model.Device;
-import se.hydroleaf.model.DeviceGroup;
-import se.hydroleaf.repository.DeviceGroupRepository;
-import se.hydroleaf.repository.DeviceRepository;
-import se.hydroleaf.service.RecordService;
 import se.hydroleaf.service.StatusService;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * MQTT bridge:
  * - Connects to broker and subscribes to configured topics.
- * - Parses incoming JSON, derives composite_id (payload or topic),
- * auto-provisions Device/DeviceGroup if missing, and persists data.
+ * - Delegates message parsing and persistence to {@link MqttMessageHandler}.
  * - Periodically pushes live snapshot to /topic/live_now via STOMP.
  */
 @Slf4j
@@ -38,34 +23,19 @@ import java.util.regex.Pattern;
 @ConditionalOnProperty(prefix = "mqtt", name = "enabled", havingValue = "true", matchIfMissing = false)
 public class MqttService implements MqttCallback {
 
-    private final ObjectMapper objectMapper;
-    private final RecordService recordService;
     private final SimpMessagingTemplate messagingTemplate;
     private final StatusService statusService;
-    private final DeviceRepository deviceRepo;
-    private final DeviceGroupRepository groupRepo;
-
-    // optional, used when auto-provisioning groups
-    @Value("${mqtt.topicPrefix:}")
-    private String topicPrefix;
-
     private final MqttClientManager clientManager;
-    private final ConcurrentHashMap<String, Instant> lastSeen = new ConcurrentHashMap<>();
+    private final MqttMessageHandler messageHandler;
 
-    public MqttService(ObjectMapper objectMapper,
-                       RecordService recordService,
-                       SimpMessagingTemplate messagingTemplate,
+    public MqttService(SimpMessagingTemplate messagingTemplate,
                        StatusService statusService,
-                       DeviceRepository deviceRepo,
-                       DeviceGroupRepository groupRepo,
-                       MqttClientManager clientManager) {
-        this.objectMapper = objectMapper;
-        this.recordService = recordService;
+                       MqttClientManager clientManager,
+                       MqttMessageHandler messageHandler) {
         this.messagingTemplate = messagingTemplate;
         this.statusService = statusService;
-        this.deviceRepo = deviceRepo;
-        this.groupRepo = groupRepo;
         this.clientManager = clientManager;
+        this.messageHandler = messageHandler;
     }
 
     @PostConstruct
@@ -86,89 +56,12 @@ public class MqttService implements MqttCallback {
     @Override
     public void messageArrived(String topic, MqttMessage message) {
         String payload = new String(message.getPayload(), StandardCharsets.UTF_8);
-        messagingTemplate.convertAndSend("/topic/" + topic, payload);
-        try {
-            JsonNode node = objectMapper.readTree(payload);
-
-            // 1) composite_id from payload or derived from topic
-            String compositeId = readCompositeId(node);
-            if (compositeId == null) {
-                compositeId = deriveCompositeIdFromTopic(topic);
-            }
-            if (compositeId == null || compositeId.isBlank()) {
-                log.warn("MQTT parse/handle failed on topic {}: missing composite_id", topic);
-                return;
-            }
-
-            // 2) auto-provision device/group if missing
-            ensureDevice(compositeId, topic);
-
-            // 3) forward all payloads to RecordService
-            recordService.saveRecord(compositeId, node);
-
-            lastSeen.put(compositeId, Instant.now());
-        } catch (Exception ex) {
-            log.error("MQTT handle error for topic {}: {}", topic, ex.getMessage(), ex);
-        }
+        messageHandler.handle(topic, payload);
     }
 
     @Override
     public void deliveryComplete(IMqttDeliveryToken token) {
         // not publishing; ignore
-    }
-
-    // -------- util: composite id --------
-
-    private static String readCompositeId(JsonNode n) {
-        if (n == null) return null;
-        if (n.hasNonNull("composite_id")) return n.get("composite_id").asText();
-        if (n.hasNonNull("compositeId")) return n.get("compositeId").asText();
-        return null;
-    }
-
-    // Accepts topics like: growSensors/S01/L02/esp32-01  -> S01-L02-esp32-01
-    private static final Pattern GROW_PATTERN =
-            Pattern.compile("^growSensors/(S\\d+)/(L\\d+)/([^/]+)$");
-
-    private String deriveCompositeIdFromTopic(String topic) {
-        if (topic == null) return null;
-        Matcher m = GROW_PATTERN.matcher(topic);
-        if (m.find()) {
-            return m.group(1) + "-" + m.group(2) + "-" + m.group(3);
-        }
-        return null;
-    }
-
-    // -------- util: ensure device/group --------
-
-    private Device ensureDevice(String compositeId, String topic) {
-        return deviceRepo.findById(compositeId).orElseGet(() -> {
-            Device d = new Device();
-            d.setCompositeId(compositeId);
-
-            String[] parts = compositeId.split("-");
-            if (parts.length >= 3) {
-                d.setSystem(parts[0]);
-                d.setLayer(parts[1]);
-                d.setDeviceId(parts[2]);
-            }
-
-            // choose a group by exact topic (best) or fallback to a default one
-            String grpKey = (topic != null && !topic.isBlank()) ? topic.split("/")[0] : topicPrefix;
-            DeviceGroup g = findOrCreateGroup(grpKey == null ? "default" : grpKey);
-            d.setGroup(g);
-
-            return deviceRepo.save(d);
-        });
-    }
-
-    private DeviceGroup findOrCreateGroup(String mqttKey) {
-        Optional<DeviceGroup> g = groupRepo.findByMqttTopic(mqttKey);
-        if (g.isPresent()) return g.get();
-
-        DeviceGroup ng = new DeviceGroup();
-        ng.setMqttTopic(mqttKey);
-        return groupRepo.save(ng);
     }
 
     // -------- live feed --------
@@ -182,16 +75,5 @@ public class MqttService implements MqttCallback {
             // avoid killing the scheduler on transient NPEs
             log.warn("sendLiveNow failed: {}", e.getMessage());
         }
-    }
-
-    // Optional: log devices that stopped sending data
-    @Scheduled(fixedDelay = 10000)
-    public void logLaggingDevices() {
-        Instant now = Instant.now();
-        lastSeen.forEach((id, ts) -> {
-            if (Duration.between(ts, now).toSeconds() > 60) {
-                log.debug("Device {} no message for >60s (lastSeen={})", id, ts);
-            }
-        });
     }
 }


### PR DESCRIPTION
## Summary
- add `MqttMessageHandler` to parse MQTT payloads, derive composite IDs, auto-provision devices and persist records
- simplify `MqttService.messageArrived` to delegate to the new handler

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e5ee8e7dc8328952181b09e0453de