### PR TITLE
refactor: extract device provisioning service from MQTT handler

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
@@ -3,19 +3,14 @@ package se.hydroleaf.mqtt;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import se.hydroleaf.model.Device;
-import se.hydroleaf.model.DeviceGroup;
-import se.hydroleaf.repository.DeviceGroupRepository;
-import se.hydroleaf.repository.DeviceRepository;
+import se.hydroleaf.service.DeviceProvisionService;
 import se.hydroleaf.service.RecordService;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -31,24 +26,18 @@ public class MqttMessageHandler {
     private final ObjectMapper objectMapper;
     private final RecordService recordService;
     private final SimpMessagingTemplate messagingTemplate;
-    private final DeviceRepository deviceRepo;
-    private final DeviceGroupRepository groupRepo;
-
-    @Value("${mqtt.topicPrefix:}")
-    private String topicPrefix;
+    private final DeviceProvisionService deviceProvisionService;
 
     private final ConcurrentHashMap<String, Instant> lastSeen = new ConcurrentHashMap<>();
 
     public MqttMessageHandler(ObjectMapper objectMapper,
                               RecordService recordService,
                               SimpMessagingTemplate messagingTemplate,
-                              DeviceRepository deviceRepo,
-                              DeviceGroupRepository groupRepo) {
+                              DeviceProvisionService deviceProvisionService) {
         this.objectMapper = objectMapper;
         this.recordService = recordService;
         this.messagingTemplate = messagingTemplate;
-        this.deviceRepo = deviceRepo;
-        this.groupRepo = groupRepo;
+        this.deviceProvisionService = deviceProvisionService;
     }
 
     public void handle(String topic, String payload) {
@@ -65,7 +54,7 @@ public class MqttMessageHandler {
                 return;
             }
 
-            ensureDevice(compositeId, topic);
+            deviceProvisionService.ensureDevice(compositeId, topic);
             recordService.saveRecord(compositeId, node);
             lastSeen.put(compositeId, Instant.now());
         } catch (Exception ex) {
@@ -90,35 +79,6 @@ public class MqttMessageHandler {
             return m.group(1) + "-" + m.group(2) + "-" + m.group(3);
         }
         return null;
-    }
-
-    private Device ensureDevice(String compositeId, String topic) {
-        return deviceRepo.findById(compositeId).orElseGet(() -> {
-            Device d = new Device();
-            d.setCompositeId(compositeId);
-
-            String[] parts = compositeId.split("-");
-            if (parts.length >= 3) {
-                d.setSystem(parts[0]);
-                d.setLayer(parts[1]);
-                d.setDeviceId(parts[2]);
-            }
-
-            String grpKey = (topic != null && !topic.isBlank()) ? topic.split("/")[0] : topicPrefix;
-            DeviceGroup g = findOrCreateGroup(grpKey == null ? "default" : grpKey);
-            d.setGroup(g);
-
-            return deviceRepo.save(d);
-        });
-    }
-
-    private DeviceGroup findOrCreateGroup(String mqttKey) {
-        Optional<DeviceGroup> g = groupRepo.findByMqttTopic(mqttKey);
-        if (g.isPresent()) return g.get();
-
-        DeviceGroup ng = new DeviceGroup();
-        ng.setMqttTopic(mqttKey);
-        return groupRepo.save(ng);
     }
 
     @Scheduled(fixedDelay = 10000)

--- a/src/main/java/se/hydroleaf/service/DeviceProvisionService.java
+++ b/src/main/java/se/hydroleaf/service/DeviceProvisionService.java
@@ -1,0 +1,55 @@
+package se.hydroleaf.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import se.hydroleaf.model.Device;
+import se.hydroleaf.model.DeviceGroup;
+import se.hydroleaf.repository.DeviceGroupRepository;
+import se.hydroleaf.repository.DeviceRepository;
+
+import java.util.Optional;
+
+@Service
+public class DeviceProvisionService {
+
+    private final DeviceRepository deviceRepo;
+    private final DeviceGroupRepository groupRepo;
+
+    @Value("${mqtt.topicPrefix:}")
+    private String topicPrefix;
+
+    public DeviceProvisionService(DeviceRepository deviceRepo,
+                                  DeviceGroupRepository groupRepo) {
+        this.deviceRepo = deviceRepo;
+        this.groupRepo = groupRepo;
+    }
+
+    public Device ensureDevice(String compositeId, String topic) {
+        return deviceRepo.findById(compositeId).orElseGet(() -> {
+            Device d = new Device();
+            d.setCompositeId(compositeId);
+
+            String[] parts = compositeId.split("-");
+            if (parts.length >= 3) {
+                d.setSystem(parts[0]);
+                d.setLayer(parts[1]);
+                d.setDeviceId(parts[2]);
+            }
+
+            String grpKey = (topic != null && !topic.isBlank()) ? topic.split("/")[0] : topicPrefix;
+            DeviceGroup g = findOrCreateGroup(grpKey == null ? "default" : grpKey);
+            d.setGroup(g);
+
+            return deviceRepo.save(d);
+        });
+    }
+
+    private DeviceGroup findOrCreateGroup(String mqttKey) {
+        Optional<DeviceGroup> g = groupRepo.findByMqttTopic(mqttKey);
+        if (g.isPresent()) return g.get();
+
+        DeviceGroup ng = new DeviceGroup();
+        ng.setMqttTopic(mqttKey);
+        return groupRepo.save(ng);
+    }
+}


### PR DESCRIPTION
## Summary
- extract device provisioning logic into new `DeviceProvisionService`
- inject `DeviceProvisionService` into `MqttMessageHandler` and delegate device creation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e604abd6083288b1e0f4db6631af2