### PR TITLE
refactor: move live feed tasks to dedicated scheduler

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttService.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttService.java
@@ -5,10 +5,7 @@ import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.paho.client.mqttv3.*;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import se.hydroleaf.service.StatusService;
 
 import java.nio.charset.StandardCharsets;
 
@@ -16,24 +13,17 @@ import java.nio.charset.StandardCharsets;
  * MQTT bridge:
  * - Connects to broker and subscribes to configured topics.
  * - Delegates message parsing and persistence to {@link MqttMessageHandler}.
- * - Periodically pushes live snapshot to /topic/live_now via STOMP.
  */
 @Slf4j
 @Service
 @ConditionalOnProperty(prefix = "mqtt", name = "enabled", havingValue = "true", matchIfMissing = false)
 public class MqttService implements MqttCallback {
 
-    private final SimpMessagingTemplate messagingTemplate;
-    private final StatusService statusService;
     private final MqttClientManager clientManager;
     private final MqttMessageHandler messageHandler;
 
-    public MqttService(SimpMessagingTemplate messagingTemplate,
-                       StatusService statusService,
-                       MqttClientManager clientManager,
+    public MqttService(MqttClientManager clientManager,
                        MqttMessageHandler messageHandler) {
-        this.messagingTemplate = messagingTemplate;
-        this.statusService = statusService;
         this.clientManager = clientManager;
         this.messageHandler = messageHandler;
     }
@@ -64,16 +54,4 @@ public class MqttService implements MqttCallback {
         // not publishing; ignore
     }
 
-    // -------- live feed --------
-
-    @Scheduled(fixedRate = 2000)
-    public void sendLiveNow() {
-        try {
-            Object snapshot = statusService.getAllSystemLayerAverages();
-            messagingTemplate.convertAndSend("/topic/live_now", snapshot);
-        } catch (Exception e) {
-            // avoid killing the scheduler on transient NPEs
-            log.warn("sendLiveNow failed: {}", e.getMessage());
-        }
-    }
 }

--- a/src/main/java/se/hydroleaf/scheduler/LiveFeedConfig.java
+++ b/src/main/java/se/hydroleaf/scheduler/LiveFeedConfig.java
@@ -1,0 +1,16 @@
+package se.hydroleaf.scheduler;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Configuration
+public class LiveFeedConfig {
+
+    @Bean
+    public ConcurrentHashMap<String, Instant> lastSeen() {
+        return new ConcurrentHashMap<>();
+    }
+}

--- a/src/main/java/se/hydroleaf/scheduler/LiveFeedScheduler.java
+++ b/src/main/java/se/hydroleaf/scheduler/LiveFeedScheduler.java
@@ -1,0 +1,51 @@
+package se.hydroleaf.scheduler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import se.hydroleaf.service.StatusService;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Periodic tasks related to live device feed.
+ */
+@Slf4j
+@Service
+public class LiveFeedScheduler {
+
+    private final StatusService statusService;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ConcurrentHashMap<String, Instant> lastSeen;
+
+    public LiveFeedScheduler(StatusService statusService,
+                              SimpMessagingTemplate messagingTemplate,
+                              ConcurrentHashMap<String, Instant> lastSeen) {
+        this.statusService = statusService;
+        this.messagingTemplate = messagingTemplate;
+        this.lastSeen = lastSeen;
+    }
+
+    @Scheduled(fixedRate = 2000)
+    public void sendLiveNow() {
+        try {
+            Object snapshot = statusService.getAllSystemLayerAverages();
+            messagingTemplate.convertAndSend("/topic/live_now", snapshot);
+        } catch (Exception e) {
+            log.warn("sendLiveNow failed: {}", e.getMessage());
+        }
+    }
+
+    @Scheduled(fixedDelay = 10000)
+    public void logLaggingDevices() {
+        Instant now = Instant.now();
+        lastSeen.forEach((id, ts) -> {
+            if (Duration.between(ts, now).toSeconds() > 60) {
+                log.debug("Device {} no message for >60s (lastSeen={})", id, ts);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add `LiveFeedScheduler` to handle live snapshot updates and lagging device logs
- expose `lastSeen` device map as bean and inject where needed
- streamline `MqttService` and `MqttMessageHandler` to focus on MQTT bridging

## Testing
- `mvn -q -e -DskipTests compile` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e614683e08328bd6debadbf18df1f