### PR TITLE
Implement live snapshot DTOs and service aggregation

### DIFF
--- a/src/main/java/se/hydroleaf/dto/LayerActuatorStatus.java
+++ b/src/main/java/se/hydroleaf/dto/LayerActuatorStatus.java
@@ -1,0 +1,5 @@
+package se.hydroleaf.dto;
+
+public record LayerActuatorStatus(
+        StatusAverageResponse airPump
+) {}

--- a/src/main/java/se/hydroleaf/dto/LayerSensorSummary.java
+++ b/src/main/java/se/hydroleaf/dto/LayerSensorSummary.java
@@ -1,0 +1,8 @@
+package se.hydroleaf.dto;
+
+public record LayerSensorSummary(
+        StatusAverageResponse light,
+        StatusAverageResponse humidity,
+        StatusAverageResponse temperature,
+        StatusAverageResponse dissolvedOxygen
+) {}

--- a/src/main/java/se/hydroleaf/dto/LiveNowSnapshot.java
+++ b/src/main/java/se/hydroleaf/dto/LiveNowSnapshot.java
@@ -1,0 +1,13 @@
+package se.hydroleaf.dto;
+
+import java.util.Map;
+
+public record LiveNowSnapshot(
+        Map<String, Map<String, LayerSnapshot>> systems
+) {
+    public record LayerSnapshot(
+            LayerActuatorStatus actuator,
+            LayerSensorSummary growSensors,
+            LayerSensorSummary waterTank
+    ) {}
+}

--- a/src/main/java/se/hydroleaf/scheduler/LiveFeedScheduler.java
+++ b/src/main/java/se/hydroleaf/scheduler/LiveFeedScheduler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import se.hydroleaf.dto.LiveNowSnapshot;
 import se.hydroleaf.service.StatusService;
 
 import java.time.Duration;
@@ -32,7 +33,7 @@ public class LiveFeedScheduler {
     @Scheduled(fixedRate = 2000)
     public void sendLiveNow() {
         try {
-            Object snapshot = statusService.getAllSystemLayerAverages();
+            LiveNowSnapshot snapshot = statusService.getLiveNowSnapshot();
             messagingTemplate.convertAndSend("/topic/live_now", snapshot);
         } catch (Exception e) {
             log.warn("sendLiveNow failed: {}", e.getMessage());


### PR DESCRIPTION
## Summary
- add LayerActuatorStatus, LayerSensorSummary and LiveNowSnapshot DTOs
- replace getAllSystemLayerAverages with getLiveNowSnapshot grouping actuator, grow sensors, and water tank data
- update LiveFeedScheduler to broadcast the new snapshot DTO

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_689edca58508832886e76a6233e58f04