### PR TITLE
Categorize sensor averages

### DIFF
--- a/src/main/java/se/hydroleaf/dto/StatusAllAverageResponse.java
+++ b/src/main/java/se/hydroleaf/dto/StatusAllAverageResponse.java
@@ -1,9 +1,9 @@
 package se.hydroleaf.dto;
 
+import java.util.Map;
+
 public record StatusAllAverageResponse(
-        StatusAverageResponse light,
-        StatusAverageResponse humidity,
-        StatusAverageResponse temperature,
-        StatusAverageResponse dissolvedOxygen,
+        Map<String, StatusAverageResponse> growSensors,
+        Map<String, StatusAverageResponse> waterTank,
         StatusAverageResponse airpump
 ) {}

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -48,16 +48,34 @@ public class StatusService {
 
     public StatusAllAverageResponse getAllAverages(String system, String layer) {
         String oxygenPumpType = "airPump";
-        List<String> sensorTypes = List.of("light", "humidity", "temperature", "dissolvedOxygen", oxygenPumpType);
+        List<String> sensorTypes = List.of(
+                "light",
+                "humidity",
+                "temperature",
+                "dissolvedOxygen",
+                "dissolvedTemp",
+                "dissolvedPH",
+                "dissolvedEC",
+                oxygenPumpType
+        );
         Map<String, StatusAverageResponse> responses = new HashMap<>();
         for (String type : sensorTypes) {
             responses.put(type, getAverage(system, layer, type));
         }
+        Map<String, StatusAverageResponse> growSensors = Map.of(
+                "light", responses.get("light"),
+                "humidity", responses.get("humidity"),
+                "temperature", responses.get("temperature")
+        );
+        Map<String, StatusAverageResponse> waterTank = Map.of(
+                "dissolvedTemp", responses.get("dissolvedTemp"),
+                "dissolvedOxygen", responses.get("dissolvedOxygen"),
+                "dissolvedPH", responses.get("dissolvedPH"),
+                "dissolvedEC", responses.get("dissolvedEC")
+        );
         return new StatusAllAverageResponse(
-                responses.get("light"),
-                responses.get("humidity"),
-                responses.get("temperature"),
-                responses.get("dissolvedOxygen"),
+                growSensors,
+                waterTank,
                 responses.get(oxygenPumpType)
         );
     }

--- a/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import se.hydroleaf.dto.StatusAllAverageResponse;
 import se.hydroleaf.dto.StatusAverageResponse;
 import se.hydroleaf.service.StatusService;
+import java.util.Map;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -50,21 +51,33 @@ class StatusControllerTest {
 
     @Test
     void getAllAveragesEndpointReturnsData() throws Exception {
+        Map<String, StatusAverageResponse> growSensors = Map.of(
+                "light", new StatusAverageResponse(1.0,1L),
+                "humidity", new StatusAverageResponse(2.0,2L),
+                "temperature", new StatusAverageResponse(3.0,3L)
+        );
+        Map<String, StatusAverageResponse> waterTank = Map.of(
+                "dissolvedTemp", new StatusAverageResponse(4.0,4L),
+                "dissolvedOxygen", new StatusAverageResponse(5.0,5L),
+                "dissolvedPH", new StatusAverageResponse(6.0,6L),
+                "dissolvedEC", new StatusAverageResponse(7.0,7L)
+        );
         StatusAllAverageResponse response = new StatusAllAverageResponse(
-                new StatusAverageResponse(1.0,1L),
-                new StatusAverageResponse(2.0,2L),
-                new StatusAverageResponse(3.0,3L),
-                new StatusAverageResponse(4.0,4L),
-                new StatusAverageResponse(5.0,5L)
+                growSensors,
+                waterTank,
+                new StatusAverageResponse(8.0,8L)
         );
         when(statusService.getAllAverages("sys", "layer")).thenReturn(response);
 
         mockMvc.perform(get("/api/status/sys/layer/all/average"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.light.average").value(1.0))
-                .andExpect(jsonPath("$.humidity.average").value(2.0))
-                .andExpect(jsonPath("$.temperature.average").value(3.0))
-                .andExpect(jsonPath("$.dissolvedOxygen.average").value(4.0))
-                .andExpect(jsonPath("$.airpump.average").value(5.0));
+                .andExpect(jsonPath("$.growSensors.light.average").value(1.0))
+                .andExpect(jsonPath("$.growSensors.humidity.average").value(2.0))
+                .andExpect(jsonPath("$.growSensors.temperature.average").value(3.0))
+                .andExpect(jsonPath("$.waterTank.dissolvedTemp.average").value(4.0))
+                .andExpect(jsonPath("$.waterTank.dissolvedOxygen.average").value(5.0))
+                .andExpect(jsonPath("$.waterTank.dissolvedPH.average").value(6.0))
+                .andExpect(jsonPath("$.waterTank.dissolvedEC.average").value(7.0))
+                .andExpect(jsonPath("$.airpump.average").value(8.0));
     }
 }

--- a/src/test/java/se/hydroleaf/service/StatusServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/StatusServiceTest.java
@@ -71,16 +71,29 @@ class StatusServiceTest {
                 .thenReturn(simpleResult(3.0, 3L));
         when(sensorDataRepository.getLatestAverage("sys", "layer", "dissolvedOxygen"))
                 .thenReturn(simpleResult(4.0, 4L));
-        when(actuatorStatusRepository.getLatestActuatorAverage("sys", "layer", "airPump"))
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "dissolvedTemp"))
                 .thenReturn(simpleResult(5.0, 5L));
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "dissolvedPH"))
+                .thenReturn(simpleResult(6.0, 6L));
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "dissolvedEC"))
+                .thenReturn(simpleResult(7.0, 7L));
+        when(actuatorStatusRepository.getLatestActuatorAverage("sys", "layer", "airPump"))
+                .thenReturn(simpleResult(8.0, 8L));
 
         StatusAllAverageResponse response = statusService.getAllAverages("sys", "layer");
 
-        assertEquals(1.0, response.light().average());
-        assertEquals(2.0, response.humidity().average());
-        assertEquals(3.0, response.temperature().average());
-        assertEquals(4.0, response.dissolvedOxygen().average());
-        assertEquals(5.0, response.airpump().average());
+        assertEquals(1.0, response.growSensors().get("light").average());
+        assertEquals(2.0, response.growSensors().get("humidity").average());
+        assertEquals(3.0, response.growSensors().get("temperature").average());
+        assertEquals(5.0, response.waterTank().get("dissolvedTemp").average());
+        assertEquals(4.0, response.waterTank().get("dissolvedOxygen").average());
+        assertEquals(6.0, response.waterTank().get("dissolvedPH").average());
+        assertEquals(7.0, response.waterTank().get("dissolvedEC").average());
+        assertEquals(8.0, response.airpump().average());
+
+        verify(sensorDataRepository).getLatestAverage("sys", "layer", "dissolvedTemp");
+        verify(sensorDataRepository).getLatestAverage("sys", "layer", "dissolvedPH");
+        verify(sensorDataRepository).getLatestAverage("sys", "layer", "dissolvedEC");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Support dissolved water metrics in `StatusService.getAllAverages`
- Split sensor averages into `growSensors` and `waterTank` sections
- Test coverage for new sensor type handling and updated API response

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_689ef287b76c83289b0379db3a05a9ac