### PR TITLE
test: validate categorized status DTOs

### DIFF
--- a/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
@@ -40,6 +40,28 @@ class StatusControllerTest {
     }
 
     @Test
+    void getAverageEndpointReturnsActuatorData() throws Exception {
+        when(statusService.getAverage("sys", "layer", "airPump"))
+                .thenReturn(new StatusAverageResponse(1.0, 2L));
+
+        mockMvc.perform(get("/api/status/sys/layer/airPump/average"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.average").value(1.0))
+                .andExpect(jsonPath("$.deviceCount").value(2));
+    }
+
+    @Test
+    void getAverageEndpointReturnsWaterTankSensorData() throws Exception {
+        when(statusService.getAverage("sys", "layer", "dissolvedOxygen"))
+                .thenReturn(new StatusAverageResponse(5.5, 4L));
+
+        mockMvc.perform(get("/api/status/sys/layer/dissolvedOxygen/average"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.average").value(5.5))
+                .andExpect(jsonPath("$.deviceCount").value(4));
+    }
+
+    @Test
     void getAverageEndpointAcceptsDifferentCase() throws Exception {
         when(statusService.getAverage("SYS", "LAYER", "Lux"))
                 .thenReturn(new StatusAverageResponse(8.0, 1L));

--- a/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
+++ b/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
@@ -1,0 +1,59 @@
+package se.hydroleaf.scheduler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import se.hydroleaf.dto.*;
+import se.hydroleaf.service.StatusService;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LiveFeedSchedulerTest {
+
+    @Mock
+    private StatusService statusService;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Test
+    void sendLiveNowPublishesSnapshotWithCategorizedDto() {
+        LiveNowSnapshot snapshot = new LiveNowSnapshot(
+                Map.of("S1", Map.of("L1",
+                        new LiveNowSnapshot.LayerSnapshot(
+                                new LayerActuatorStatus(new StatusAverageResponse(1.0,1L)),
+                                new GrowSensorSummary(
+                                        new StatusAverageResponse(2.0,1L),
+                                        new StatusAverageResponse(3.0,1L),
+                                        new StatusAverageResponse(4.0,1L)
+                                ),
+                                new WaterTankSummary(
+                                        new StatusAverageResponse(5.0,1L),
+                                        new StatusAverageResponse(6.0,1L),
+                                        new StatusAverageResponse(7.0,1L),
+                                        new StatusAverageResponse(8.0,1L)
+                                )
+                        )))
+        );
+        when(statusService.getLiveNowSnapshot()).thenReturn(snapshot);
+
+        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, messagingTemplate, new ConcurrentHashMap<>());
+        scheduler.sendLiveNow();
+
+        ArgumentCaptor<LiveNowSnapshot> captor = ArgumentCaptor.forClass(LiveNowSnapshot.class);
+        verify(messagingTemplate).convertAndSend(eq("/topic/live_now"), captor.capture());
+
+        LiveNowSnapshot sent = captor.getValue();
+        assertEquals(6.0, sent.systems().get("S1").get("L1").waterTank().dissolvedOxygen().average());
+        assertEquals(1.0, sent.systems().get("S1").get("L1").actuator().airPump().average());
+    }
+}
+

--- a/src/test/java/se/hydroleaf/service/StatusServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/StatusServiceTest.java
@@ -48,6 +48,19 @@ class StatusServiceTest {
     }
 
     @Test
+    void getAverageUsesSensorDataRepositoryForWaterTankSensor() {
+        AverageResult avg = simpleResult(9.9, 4L);
+        when(sensorDataRepository.getLatestAverage("Sys", "Layer", "dissolvedOxygen"))
+                .thenReturn(avg);
+
+        StatusAverageResponse response = statusService.getAverage("Sys", "Layer", "dissolvedOxygen");
+        assertEquals(9.9, response.average());
+        assertEquals(4L, response.deviceCount());
+        verify(sensorDataRepository).getLatestAverage("Sys", "Layer", "dissolvedOxygen");
+        verifyNoInteractions(actuatorStatusRepository);
+    }
+
+    @Test
     void getAverageUsesActuatorRepositoryForAirpump() {
         AverageResult avg = simpleResult(1.5, 2L);
         when(actuatorStatusRepository.getLatestActuatorAverage("Sys", "Layer", "airpump"))


### PR DESCRIPTION
## Summary
- update status tests to assert new growSensor, waterTank, and actuator DTOs
- cover actuator status retrieval and water-tank averages via controller and service
- add LiveFeedScheduler test to validate `/topic/live_now` payload structure

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689ef40631f08328b70f42c07cf16f60