### PR TITLE
refactor: rename summary fields and add units

### DIFF
--- a/src/main/java/se/hydroleaf/dto/GrowSensorSummary.java
+++ b/src/main/java/se/hydroleaf/dto/GrowSensorSummary.java
@@ -3,5 +3,5 @@ package se.hydroleaf.dto;
 public record GrowSensorSummary(
         StatusAverageResponse light,
         StatusAverageResponse humidity,
-        StatusAverageResponse temperature
+        StatusAverageResponse airTemperature
 ) {}

--- a/src/main/java/se/hydroleaf/dto/StatusAverageResponse.java
+++ b/src/main/java/se/hydroleaf/dto/StatusAverageResponse.java
@@ -1,3 +1,8 @@
 package se.hydroleaf.dto;
 
-public record StatusAverageResponse(Double average, long deviceCount) {}
+/**
+ * Represents an average value for a sensor or actuator together with its unit
+ * and how many devices contributed to the average.
+ */
+public record StatusAverageResponse(Double average, String unit, long deviceCount) {}
+

--- a/src/main/java/se/hydroleaf/dto/WaterTankSummary.java
+++ b/src/main/java/se/hydroleaf/dto/WaterTankSummary.java
@@ -1,8 +1,8 @@
 package se.hydroleaf.dto;
 
 public record WaterTankSummary(
-        StatusAverageResponse dissolvedTemp,
+        StatusAverageResponse waterTemperature,
         StatusAverageResponse dissolvedOxygen,
-        StatusAverageResponse dissolvedPH,
-        StatusAverageResponse dissolvedEC
+        StatusAverageResponse pH,
+        StatusAverageResponse electricalConductivity
 ) {}

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -44,7 +44,8 @@ public class StatusService {
         }
         Double avg = (result != null && result.getAverage() != null) ? (double) Math.round(result.getAverage() * 10) / 10 : null;
         long count = result != null && result.getCount() != null ? result.getCount() : 0L;
-        return new StatusAverageResponse(avg, count);
+        String unit = getUnit(sensorType);
+        return new StatusAverageResponse(avg, unit, count);
     }
 
     public StatusAllAverageResponse getAllAverages(String system, String layer) {
@@ -52,11 +53,11 @@ public class StatusService {
         List<String> sensorTypes = List.of(
                 "light",
                 "humidity",
-                "temperature",
+                "airTemperature",
                 "dissolvedOxygen",
-                "dissolvedTemp",
-                "dissolvedPH",
-                "dissolvedEC",
+                "waterTemperature",
+                "pH",
+                "electricalConductivity",
                 oxygenPumpType
         );
         Map<String, StatusAverageResponse> responses = new HashMap<>();
@@ -66,13 +67,13 @@ public class StatusService {
         Map<String, StatusAverageResponse> growSensors = Map.of(
                 "light", responses.get("light"),
                 "humidity", responses.get("humidity"),
-                "temperature", responses.get("temperature")
+                "airTemperature", responses.get("airTemperature")
         );
         Map<String, StatusAverageResponse> waterTank = Map.of(
-                "dissolvedTemp", responses.get("dissolvedTemp"),
+                "waterTemperature", responses.get("waterTemperature"),
                 "dissolvedOxygen", responses.get("dissolvedOxygen"),
-                "dissolvedPH", responses.get("dissolvedPH"),
-                "dissolvedEC", responses.get("dissolvedEC")
+                "pH", responses.get("pH"),
+                "electricalConductivity", responses.get("electricalConductivity")
         );
         return new StatusAllAverageResponse(
                 growSensors,
@@ -99,13 +100,13 @@ public class StatusService {
             GrowSensorSummary environment = new GrowSensorSummary(
                     getAverage(system, layer, "light"),
                     getAverage(system, layer, "humidity"),
-                    getAverage(system, layer, "temperature")
+                    getAverage(system, layer, "airTemperature")
             );
             WaterTankSummary water = new WaterTankSummary(
-                    getAverage(system, layer, "dissolvedTemp"),
+                    getAverage(system, layer, "waterTemperature"),
                     getAverage(system, layer, "dissolvedOxygen"),
-                    getAverage(system, layer, "dissolvedPH"),
-                    getAverage(system, layer, "dissolvedEC")
+                    getAverage(system, layer, "pH"),
+                    getAverage(system, layer, "electricalConductivity")
             );
 
             SystemSnapshot snapshot = new SystemSnapshot(java.time.Instant.now(), actuator, water, environment);
@@ -119,5 +120,21 @@ public class StatusService {
             return false;
         }
         return sensorType.equalsIgnoreCase("airPump") || sensorType.equalsIgnoreCase("airpump");
+    }
+
+    private String getUnit(String sensorType) {
+        if (sensorType == null) {
+            return null;
+        }
+        return switch (sensorType.toLowerCase()) {
+            case "light" -> "lux";
+            case "humidity" -> "%";
+            case "airtemperature", "watertemperature" -> "°C";
+            case "dissolvedoxygen" -> "mg/L";
+            case "ph" -> "pH";
+            case "electricalconductivity" -> "µS/cm";
+            case "airpump" -> "status";
+            default -> null;
+        };
     }
 }

--- a/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
@@ -30,19 +30,20 @@ class StatusControllerTest {
 
     @Test
     void getAverageEndpointReturnsData() throws Exception {
-        when(statusService.getAverage("sys", "layer", "lux"))
-                .thenReturn(new StatusAverageResponse(12.5, 3L));
+        when(statusService.getAverage("sys", "layer", "light"))
+                .thenReturn(new StatusAverageResponse(12.5, "lux", 3L));
 
-        mockMvc.perform(get("/api/status/sys/layer/lux/average"))
+        mockMvc.perform(get("/api/status/sys/layer/light/average"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.average").value(12.5))
+                .andExpect(jsonPath("$.unit").value("lux"))
                 .andExpect(jsonPath("$.deviceCount").value(3));
     }
 
     @Test
     void getAverageEndpointReturnsActuatorData() throws Exception {
         when(statusService.getAverage("sys", "layer", "airPump"))
-                .thenReturn(new StatusAverageResponse(1.0, 2L));
+                .thenReturn(new StatusAverageResponse(1.0, "status", 2L));
 
         mockMvc.perform(get("/api/status/sys/layer/airPump/average"))
                 .andExpect(status().isOk())
@@ -53,7 +54,7 @@ class StatusControllerTest {
     @Test
     void getAverageEndpointReturnsWaterTankSensorData() throws Exception {
         when(statusService.getAverage("sys", "layer", "dissolvedOxygen"))
-                .thenReturn(new StatusAverageResponse(5.5, 4L));
+                .thenReturn(new StatusAverageResponse(5.5, "mg/L", 4L));
 
         mockMvc.perform(get("/api/status/sys/layer/dissolvedOxygen/average"))
                 .andExpect(status().isOk())
@@ -63,31 +64,32 @@ class StatusControllerTest {
 
     @Test
     void getAverageEndpointAcceptsDifferentCase() throws Exception {
-        when(statusService.getAverage("SYS", "LAYER", "Lux"))
-                .thenReturn(new StatusAverageResponse(8.0, 1L));
-        mockMvc.perform(get("/api/status/SYS/LAYER/Lux/average"))
+        when(statusService.getAverage("SYS", "LAYER", "Light"))
+                .thenReturn(new StatusAverageResponse(8.0, "lux", 1L));
+        mockMvc.perform(get("/api/status/SYS/LAYER/Light/average"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.average").value(8.0))
+                .andExpect(jsonPath("$.unit").value("lux"))
                 .andExpect(jsonPath("$.deviceCount").value(1));
     }
 
     @Test
     void getAllAveragesEndpointReturnsData() throws Exception {
         Map<String, StatusAverageResponse> growSensors = Map.of(
-                "light", new StatusAverageResponse(1.0,1L),
-                "humidity", new StatusAverageResponse(2.0,2L),
-                "temperature", new StatusAverageResponse(3.0,3L)
+                "light", new StatusAverageResponse(1.0, "lux",1L),
+                "humidity", new StatusAverageResponse(2.0, "%",2L),
+                "airTemperature", new StatusAverageResponse(3.0, "°C",3L)
         );
         Map<String, StatusAverageResponse> waterTank = Map.of(
-                "dissolvedTemp", new StatusAverageResponse(4.0,4L),
-                "dissolvedOxygen", new StatusAverageResponse(5.0,5L),
-                "dissolvedPH", new StatusAverageResponse(6.0,6L),
-                "dissolvedEC", new StatusAverageResponse(7.0,7L)
+                "waterTemperature", new StatusAverageResponse(4.0, "°C",4L),
+                "dissolvedOxygen", new StatusAverageResponse(5.0, "mg/L",5L),
+                "pH", new StatusAverageResponse(6.0, "pH",6L),
+                "electricalConductivity", new StatusAverageResponse(7.0, "µS/cm",7L)
         );
         StatusAllAverageResponse response = new StatusAllAverageResponse(
                 growSensors,
                 waterTank,
-                new StatusAverageResponse(8.0,8L)
+                new StatusAverageResponse(8.0, "status",8L)
         );
         when(statusService.getAllAverages("sys", "layer")).thenReturn(response);
 
@@ -95,11 +97,11 @@ class StatusControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.growSensors.light.average").value(1.0))
                 .andExpect(jsonPath("$.growSensors.humidity.average").value(2.0))
-                .andExpect(jsonPath("$.growSensors.temperature.average").value(3.0))
-                .andExpect(jsonPath("$.waterTank.dissolvedTemp.average").value(4.0))
+                .andExpect(jsonPath("$.growSensors.airTemperature.average").value(3.0))
+                .andExpect(jsonPath("$.waterTank.waterTemperature.average").value(4.0))
                 .andExpect(jsonPath("$.waterTank.dissolvedOxygen.average").value(5.0))
-                .andExpect(jsonPath("$.waterTank.dissolvedPH.average").value(6.0))
-                .andExpect(jsonPath("$.waterTank.dissolvedEC.average").value(7.0))
+                .andExpect(jsonPath("$.waterTank.pH.average").value(6.0))
+                .andExpect(jsonPath("$.waterTank.electricalConductivity.average").value(7.0))
                 .andExpect(jsonPath("$.airpump.average").value(8.0));
     }
 }

--- a/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
+++ b/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
@@ -30,17 +30,17 @@ class LiveFeedSchedulerTest {
                 Map.of("S1",
                         new SystemSnapshot(
                                 java.time.Instant.now(),
-                                new LayerActuatorStatus(new StatusAverageResponse(1.0,1L)),
+                                new LayerActuatorStatus(new StatusAverageResponse(1.0,"status",1L)),
                                 new WaterTankSummary(
-                                        new StatusAverageResponse(5.0,1L),
-                                        new StatusAverageResponse(6.0,1L),
-                                        new StatusAverageResponse(7.0,1L),
-                                        new StatusAverageResponse(8.0,1L)
+                                        new StatusAverageResponse(5.0,"°C",1L),
+                                        new StatusAverageResponse(6.0,"mg/L",1L),
+                                        new StatusAverageResponse(7.0,"pH",1L),
+                                        new StatusAverageResponse(8.0,"µS/cm",1L)
                                 ),
                                 new GrowSensorSummary(
-                                        new StatusAverageResponse(2.0,1L),
-                                        new StatusAverageResponse(3.0,1L),
-                                        new StatusAverageResponse(4.0,1L)
+                                        new StatusAverageResponse(2.0,"lux",1L),
+                                        new StatusAverageResponse(3.0,"%",1L),
+                                        new StatusAverageResponse(4.0,"°C",1L)
                                 )
                         ))
         );

--- a/src/test/java/se/hydroleaf/service/StatusServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/StatusServiceTest.java
@@ -42,6 +42,7 @@ class StatusServiceTest {
 
         StatusAverageResponse response = statusService.getAverage("Sys", "Layer", "light");
         assertEquals(10.0, response.average());
+        assertEquals("lux", response.unit());
         assertEquals(3L, response.deviceCount());
         verify(sensorDataRepository).getLatestAverage("Sys", "Layer", "light");
         verifyNoInteractions(actuatorStatusRepository);
@@ -55,6 +56,7 @@ class StatusServiceTest {
 
         StatusAverageResponse response = statusService.getAverage("Sys", "Layer", "dissolvedOxygen");
         assertEquals(9.9, response.average());
+        assertEquals("mg/L", response.unit());
         assertEquals(4L, response.deviceCount());
         verify(sensorDataRepository).getLatestAverage("Sys", "Layer", "dissolvedOxygen");
         verifyNoInteractions(actuatorStatusRepository);
@@ -68,6 +70,7 @@ class StatusServiceTest {
 
         StatusAverageResponse response = statusService.getAverage("Sys", "Layer", "airpump");
         assertEquals(1.5, response.average());
+        assertEquals("status", response.unit());
         assertEquals(2L, response.deviceCount());
         verify(actuatorStatusRepository).getLatestActuatorAverage("Sys", "Layer", "airpump");
         verifyNoMoreInteractions(actuatorStatusRepository);
@@ -80,15 +83,15 @@ class StatusServiceTest {
                 .thenReturn(simpleResult(1.0, 1L));
         when(sensorDataRepository.getLatestAverage("sys", "layer", "humidity"))
                 .thenReturn(simpleResult(2.0, 2L));
-        when(sensorDataRepository.getLatestAverage("sys", "layer", "temperature"))
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "airTemperature"))
                 .thenReturn(simpleResult(3.0, 3L));
         when(sensorDataRepository.getLatestAverage("sys", "layer", "dissolvedOxygen"))
                 .thenReturn(simpleResult(4.0, 4L));
-        when(sensorDataRepository.getLatestAverage("sys", "layer", "dissolvedTemp"))
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "waterTemperature"))
                 .thenReturn(simpleResult(5.0, 5L));
-        when(sensorDataRepository.getLatestAverage("sys", "layer", "dissolvedPH"))
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "pH"))
                 .thenReturn(simpleResult(6.0, 6L));
-        when(sensorDataRepository.getLatestAverage("sys", "layer", "dissolvedEC"))
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "electricalConductivity"))
                 .thenReturn(simpleResult(7.0, 7L));
         when(actuatorStatusRepository.getLatestActuatorAverage("sys", "layer", "airPump"))
                 .thenReturn(simpleResult(8.0, 8L));
@@ -97,16 +100,16 @@ class StatusServiceTest {
 
         assertEquals(1.0, response.growSensors().get("light").average());
         assertEquals(2.0, response.growSensors().get("humidity").average());
-        assertEquals(3.0, response.growSensors().get("temperature").average());
-        assertEquals(5.0, response.waterTank().get("dissolvedTemp").average());
+        assertEquals(3.0, response.growSensors().get("airTemperature").average());
+        assertEquals(5.0, response.waterTank().get("waterTemperature").average());
         assertEquals(4.0, response.waterTank().get("dissolvedOxygen").average());
-        assertEquals(6.0, response.waterTank().get("dissolvedPH").average());
-        assertEquals(7.0, response.waterTank().get("dissolvedEC").average());
+        assertEquals(6.0, response.waterTank().get("pH").average());
+        assertEquals(7.0, response.waterTank().get("electricalConductivity").average());
         assertEquals(8.0, response.airpump().average());
 
-        verify(sensorDataRepository).getLatestAverage("sys", "layer", "dissolvedTemp");
-        verify(sensorDataRepository).getLatestAverage("sys", "layer", "dissolvedPH");
-        verify(sensorDataRepository).getLatestAverage("sys", "layer", "dissolvedEC");
+        verify(sensorDataRepository).getLatestAverage("sys", "layer", "waterTemperature");
+        verify(sensorDataRepository).getLatestAverage("sys", "layer", "pH");
+        verify(sensorDataRepository).getLatestAverage("sys", "layer", "electricalConductivity");
     }
 
     @Test
@@ -115,14 +118,14 @@ class StatusServiceTest {
         Device d2 = Device.builder().compositeId("2").system("S02").layer("L01").build();
         when(deviceRepository.findAll()).thenReturn(java.util.List.of(d1, d2));
 
-        StatusAverageResponse pump = new StatusAverageResponse(1.0, 1L);
-        StatusAverageResponse light = new StatusAverageResponse(2.0, 2L);
-        StatusAverageResponse humidity = new StatusAverageResponse(3.0, 3L);
-        StatusAverageResponse temp = new StatusAverageResponse(4.0, 4L);
-        StatusAverageResponse dTemp = new StatusAverageResponse(5.0, 5L);
-        StatusAverageResponse dOxy = new StatusAverageResponse(6.0, 6L);
-        StatusAverageResponse dPh = new StatusAverageResponse(7.0, 7L);
-        StatusAverageResponse dEc = new StatusAverageResponse(8.0, 8L);
+        StatusAverageResponse pump = new StatusAverageResponse(1.0, "status",1L);
+        StatusAverageResponse light = new StatusAverageResponse(2.0, "lux",2L);
+        StatusAverageResponse humidity = new StatusAverageResponse(3.0, "%",3L);
+        StatusAverageResponse temp = new StatusAverageResponse(4.0, "°C",4L);
+        StatusAverageResponse dTemp = new StatusAverageResponse(5.0, "°C",5L);
+        StatusAverageResponse dOxy = new StatusAverageResponse(6.0, "mg/L",6L);
+        StatusAverageResponse dPh = new StatusAverageResponse(7.0, "pH",7L);
+        StatusAverageResponse dEc = new StatusAverageResponse(8.0, "µS/cm",8L);
 
         doAnswer(invocation -> {
             String type = invocation.getArgument(2);
@@ -130,11 +133,11 @@ class StatusServiceTest {
                 case "airPump" -> pump;
                 case "light" -> light;
                 case "humidity" -> humidity;
-                case "temperature" -> temp;
-                case "dissolvedTemp" -> dTemp;
+                case "airTemperature" -> temp;
+                case "waterTemperature" -> dTemp;
                 case "dissolvedOxygen" -> dOxy;
-                case "dissolvedPH" -> dPh;
-                case "dissolvedEC" -> dEc;
+                case "pH" -> dPh;
+                case "electricalConductivity" -> dEc;
                 default -> null;
             };
         }).when(statusService).getAverage(anyString(), anyString(), anyString());
@@ -159,10 +162,10 @@ class StatusServiceTest {
         Device valid = Device.builder().compositeId("5").system("S01").layer("L01").build();
         when(deviceRepository.findAll()).thenReturn(java.util.List.of(d1, d2, d3, d4, valid));
 
-        StatusAverageResponse pump = new StatusAverageResponse(1.0, 1L);
+        StatusAverageResponse pump = new StatusAverageResponse(1.0, "status",1L);
         doAnswer(invocation -> {
             String type = invocation.getArgument(2);
-            return "airPump".equals(type) ? pump : new StatusAverageResponse(null, 0L);
+            return "airPump".equals(type) ? pump : new StatusAverageResponse(null, null,0L);
         }).when(statusService).getAverage(anyString(), anyString(), anyString());
 
         LiveNowSnapshot result = statusService.getLiveNowSnapshot();


### PR DESCRIPTION
## Summary
- rename summary DTO fields to light, humidity, airTemperature, waterTemperature, pH, and electricalConductivity
- add unit to StatusAverageResponse for consistent measurement units
- update service logic, controllers, and tests for new names and units

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f26d02c648328bfa1b08d6c05747f