### PR TITLE
Add lastUpdate timestamp to layer snapshots

### DIFF
--- a/src/main/java/se/hydroleaf/dto/SystemSnapshot.java
+++ b/src/main/java/se/hydroleaf/dto/SystemSnapshot.java
@@ -1,10 +1,23 @@
 package se.hydroleaf.dto;
 
 import java.time.Instant;
+import java.util.Map;
 
+/**
+ * Snapshot of a system containing snapshots for each layer.
+ */
 public record SystemSnapshot(
-        Instant lastUpdate,
-        LayerActuatorStatus actuators,
-        WaterTankSummary water,
-        GrowSensorSummary environment
-) {}
+        Map<String, LayerSnapshot> layers
+) {
+
+    /**
+     * Snapshot of a single layer with the time of the last update.
+     */
+    public record LayerSnapshot(
+            Instant lastUpdate,
+            LayerActuatorStatus actuators,
+            WaterTankSummary water,
+            GrowSensorSummary environment
+    ) {}
+}
+

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -15,6 +15,7 @@ import se.hydroleaf.repository.AverageResult;
 import se.hydroleaf.repository.DeviceRepository;
 import se.hydroleaf.repository.SensorDataRepository;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,8 +110,13 @@ public class StatusService {
                     getAverage(system, layer, "electricalConductivity")
             );
 
-            SystemSnapshot snapshot = new SystemSnapshot(java.time.Instant.now(), actuator, water, environment);
-            result.put(system, snapshot);
+            SystemSnapshot systemSnapshot = result.computeIfAbsent(system, s -> new SystemSnapshot(new HashMap<>()));
+            systemSnapshot.layers().put(layer, new SystemSnapshot.LayerSnapshot(
+                    Instant.now(),
+                    actuator,
+                    water,
+                    environment
+            ));
         }
         return new LiveNowSnapshot(result);
     }

--- a/src/test/java/se/hydroleaf/service/StatusServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/StatusServiceTest.java
@@ -16,6 +16,7 @@ import se.hydroleaf.repository.DeviceRepository;
 import se.hydroleaf.repository.SensorDataRepository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -144,9 +145,10 @@ class StatusServiceTest {
 
         LiveNowSnapshot result = statusService.getLiveNowSnapshot();
 
-        assertEquals(pump, result.systems().get("S01").actuators().airPump());
-        assertEquals(light, result.systems().get("S01").environment().light());
-        assertEquals(dOxy, result.systems().get("S02").water().dissolvedOxygen());
+        assertEquals(pump, result.systems().get("S01").layers().get("L01").actuators().airPump());
+        assertEquals(light, result.systems().get("S01").layers().get("L01").environment().light());
+        assertEquals(dOxy, result.systems().get("S02").layers().get("L01").water().dissolvedOxygen());
+        assertNotNull(result.systems().get("S01").layers().get("L01").lastUpdate());
 
         verify(statusService, atLeastOnce()).getAverage("S01", "L01", "airPump");
         verify(statusService, atLeastOnce()).getAverage("S01", "L01", "light");
@@ -171,7 +173,8 @@ class StatusServiceTest {
         LiveNowSnapshot result = statusService.getLiveNowSnapshot();
 
         assertEquals(1, result.systems().size());
-        assertEquals(pump, result.systems().get("S01").actuators().airPump());
+        assertEquals(pump, result.systems().get("S01").layers().get("L01").actuators().airPump());
+        assertNotNull(result.systems().get("S01").layers().get("L01").lastUpdate());
         verify(statusService, atLeastOnce()).getAverage("S01", "L01", "airPump");
     }
 


### PR DESCRIPTION
## Summary
- Track `lastUpdate` per layer within `SystemSnapshot`
- Populate layer timestamps when building live snapshots
- Adjust scheduler and service tests to validate new field

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f28b25a288328ba6cfaba96633196