### PR TITLE
Refactor system snapshot to use layer arrays

### DIFF
--- a/src/main/java/se/hydroleaf/dto/SystemSnapshot.java
+++ b/src/main/java/se/hydroleaf/dto/SystemSnapshot.java
@@ -1,19 +1,28 @@
 package se.hydroleaf.dto;
 
 import java.time.Instant;
-import java.util.Map;
+import java.util.List;
 
 /**
- * Snapshot of a system containing snapshots for each layer.
+ * Snapshot of a system containing categorized layer snapshots for water and environment.
  */
 public record SystemSnapshot(
-        Map<String, LayerSnapshot> layers
+        CategorySnapshot water,
+        CategorySnapshot environment
 ) {
+
+    /**
+     * Wrapper for layer snapshots categorized by type.
+     */
+    public record CategorySnapshot(
+            List<LayerSnapshot> byLayer
+    ) {}
 
     /**
      * Snapshot of a single layer with the time of the last update.
      */
     public record LayerSnapshot(
+            String layerId,
             Instant lastUpdate,
             LayerActuatorStatus actuators,
             WaterTankSummary water,


### PR DESCRIPTION
## Summary
- Represent water and environment snapshots as `byLayer` lists in `SystemSnapshot`
- Update data aggregation to produce layer snapshot lists with embedded `layerId`
- Adjust unit and scheduler tests for new layer array structure

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f2fe4f4cc8328b283b037466a1197