### PR TITLE
refactor: simplify system snapshot layers

### DIFF
--- a/src/main/java/se/hydroleaf/dto/SystemSnapshot.java
+++ b/src/main/java/se/hydroleaf/dto/SystemSnapshot.java
@@ -4,22 +4,15 @@ import java.time.Instant;
 import java.util.List;
 
 /**
- * Snapshot of a system containing categorized layer snapshots for water and environment.
+ * Snapshot of a system containing all layer snapshots.
  */
 public record SystemSnapshot(
-        CategorySnapshot water,
-        CategorySnapshot environment
+        List<LayerSnapshot> layers
 ) {
 
     /**
-     * Wrapper for layer snapshots categorized by type.
-     */
-    public record CategorySnapshot(
-            List<LayerSnapshot> byLayer
-    ) {}
-
-    /**
      * Snapshot of a single layer with the time of the last update.
+     * Holds water, environment and actuator information for the layer.
      */
     public record LayerSnapshot(
             String layerId,

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -123,8 +123,7 @@ public class StatusService {
 
         Map<String, SystemSnapshot> result = new HashMap<>();
         for (Map.Entry<String, List<SystemSnapshot.LayerSnapshot>> entry : systemLayers.entrySet()) {
-            SystemSnapshot.CategorySnapshot snapshot = new SystemSnapshot.CategorySnapshot(entry.getValue());
-            result.put(entry.getKey(), new SystemSnapshot(snapshot, snapshot));
+            result.put(entry.getKey(), new SystemSnapshot(entry.getValue()));
         }
         return new LiveNowSnapshot(result);
     }

--- a/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
+++ b/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
@@ -32,7 +32,7 @@ class LiveFeedSchedulerTest {
     private SimpMessagingTemplate messagingTemplate;
 
     @Test
-    void sendLiveNowPublishesSnapshotWithCategorizedDto() throws Exception {
+    void sendLiveNowPublishesSnapshotWithLayers() throws Exception {
         SystemSnapshot.LayerSnapshot layerSnapshot = new SystemSnapshot.LayerSnapshot(
                 "L1",
                 java.time.Instant.now(),
@@ -49,9 +49,8 @@ class LiveFeedSchedulerTest {
                         new StatusAverageResponse(4.0, "°C", 1L)
                 )
         );
-        SystemSnapshot.CategorySnapshot categorySnapshot = new SystemSnapshot.CategorySnapshot(List.of(layerSnapshot));
         LiveNowSnapshot snapshot = new LiveNowSnapshot(
-                Map.of("S1", new SystemSnapshot(categorySnapshot, categorySnapshot))
+                Map.of("S1", new SystemSnapshot(List.of(layerSnapshot)))
         );
         when(statusService.getLiveNowSnapshot()).thenReturn(snapshot);
 
@@ -65,7 +64,7 @@ class LiveFeedSchedulerTest {
         verify(messagingTemplate).convertAndSend(eq("/topic/live_now"), captor.capture());
 
         LiveNowSnapshot sent = mapper.readValue(captor.getValue(), LiveNowSnapshot.class);
-        SystemSnapshot.LayerSnapshot sentLayer = sent.systems().get("S1").water().byLayer().get(0);
+        SystemSnapshot.LayerSnapshot sentLayer = sent.systems().get("S1").layers().get(0);
         assertEquals(6.0, sentLayer.water().dissolvedOxygen().average());
         assertEquals(1.0, sentLayer.actuators().airPump().average());
         assertNotNull(sentLayer.lastUpdate());

--- a/src/test/java/se/hydroleaf/service/StatusServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/StatusServiceTest.java
@@ -146,10 +146,10 @@ class StatusServiceTest {
 
         LiveNowSnapshot result = statusService.getLiveNowSnapshot();
 
-        SystemSnapshot.LayerSnapshot s01Layer = result.systems().get("S01").water().byLayer().stream()
+        SystemSnapshot.LayerSnapshot s01Layer = result.systems().get("S01").layers().stream()
                 .filter(l -> l.layerId().equals("L01"))
                 .findFirst().orElseThrow();
-        SystemSnapshot.LayerSnapshot s02Layer = result.systems().get("S02").water().byLayer().stream()
+        SystemSnapshot.LayerSnapshot s02Layer = result.systems().get("S02").layers().stream()
                 .filter(l -> l.layerId().equals("L01"))
                 .findFirst().orElseThrow();
         assertEquals(pump, s01Layer.actuators().airPump());
@@ -180,7 +180,7 @@ class StatusServiceTest {
         LiveNowSnapshot result = statusService.getLiveNowSnapshot();
 
         assertEquals(1, result.systems().size());
-        SystemSnapshot.LayerSnapshot layerSnapshot = result.systems().get("S01").water().byLayer().get(0);
+        SystemSnapshot.LayerSnapshot layerSnapshot = result.systems().get("S01").layers().get(0);
         assertEquals(pump, layerSnapshot.actuators().airPump());
         assertNotNull(layerSnapshot.lastUpdate());
         verify(statusService, atLeastOnce()).getAverage("S01", "L01", "airPump");


### PR DESCRIPTION
## Summary
- remove water/environment categories from `SystemSnapshot` and track a single list of layer snapshots
- build `SystemSnapshot` directly from layer snapshots in `StatusService#getLiveNowSnapshot`
- adjust scheduler and service tests for new JSON structure

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f33ccf7cc83288b1bea4faac9551a