### PR TITLE
Deduplicate layer snapshots in live feed

### DIFF
--- a/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
+++ b/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
@@ -64,6 +64,7 @@ class LiveFeedSchedulerTest {
         verify(messagingTemplate).convertAndSend(eq("/topic/live_now"), captor.capture());
 
         LiveNowSnapshot sent = mapper.readValue(captor.getValue(), LiveNowSnapshot.class);
+        assertEquals(1, sent.systems().get("S1").layers().size());
         SystemSnapshot.LayerSnapshot sentLayer = sent.systems().get("S1").layers().get(0);
         assertEquals(6.0, sentLayer.water().dissolvedOxygen().average());
         assertEquals(1.0, sentLayer.actuators().airPump().average());


### PR DESCRIPTION
## Summary
- ensure each system's layers are stored uniquely via a map and converted back to a list for snapshot creation
- adjust tests to cover duplicate devices and enforce unique layer expectations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM – network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f353b2da08328837111b046ffaf6d