### PR TITLE
Add system-level metrics to live snapshots

### DIFF
--- a/src/main/java/se/hydroleaf/controller/StatusController.java
+++ b/src/main/java/se/hydroleaf/controller/StatusController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import se.hydroleaf.dto.StatusAllAverageResponse;
 import se.hydroleaf.dto.StatusAverageResponse;
+import se.hydroleaf.dto.LiveNowSnapshot;
 import se.hydroleaf.service.StatusService;
 
 @RestController
@@ -31,5 +32,10 @@ public class StatusController {
             @PathVariable String system,
             @PathVariable String layer) {
         return statusService.getAllAverages(system, layer);
+    }
+
+    @GetMapping("/live-now")
+    public LiveNowSnapshot getLiveNowSnapshot() {
+        return statusService.getLiveNowSnapshot();
     }
 }

--- a/src/main/java/se/hydroleaf/dto/SystemActuatorStatus.java
+++ b/src/main/java/se/hydroleaf/dto/SystemActuatorStatus.java
@@ -1,0 +1,5 @@
+package se.hydroleaf.dto;
+
+public record SystemActuatorStatus(
+        StatusAverageResponse airPump
+) {}

--- a/src/main/java/se/hydroleaf/dto/SystemSnapshot.java
+++ b/src/main/java/se/hydroleaf/dto/SystemSnapshot.java
@@ -7,6 +7,10 @@ import java.util.List;
  * Snapshot of a system containing all layer snapshots.
  */
 public record SystemSnapshot(
+        Instant lastUpdate,
+        SystemActuatorStatus actuators,
+        WaterTankSummary water,
+        GrowSensorSummary environment,
         List<LayerSnapshot> layers
 ) {
 

--- a/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
+++ b/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
@@ -49,8 +49,24 @@ class LiveFeedSchedulerTest {
                         new StatusAverageResponse(4.0, "°C", 1L)
                 )
         );
+        SystemSnapshot systemSnapshot = new SystemSnapshot(
+                java.time.Instant.now(),
+                new SystemActuatorStatus(new StatusAverageResponse(1.0, "status", 1L)),
+                new WaterTankSummary(
+                        new StatusAverageResponse(5.0, "°C", 1L),
+                        new StatusAverageResponse(6.0, "mg/L", 1L),
+                        new StatusAverageResponse(7.0, "pH", 1L),
+                        new StatusAverageResponse(8.0, "µS/cm", 1L)
+                ),
+                new GrowSensorSummary(
+                        new StatusAverageResponse(2.0, "lux", 1L),
+                        new StatusAverageResponse(3.0, "%", 1L),
+                        new StatusAverageResponse(4.0, "°C", 1L)
+                ),
+                List.of(layerSnapshot)
+        );
         LiveNowSnapshot snapshot = new LiveNowSnapshot(
-                Map.of("S1", new SystemSnapshot(List.of(layerSnapshot)))
+                Map.of("S1", systemSnapshot)
         );
         when(statusService.getLiveNowSnapshot()).thenReturn(snapshot);
 
@@ -65,10 +81,12 @@ class LiveFeedSchedulerTest {
 
         LiveNowSnapshot sent = mapper.readValue(captor.getValue(), LiveNowSnapshot.class);
         assertEquals(1, sent.systems().get("S1").layers().size());
-        SystemSnapshot.LayerSnapshot sentLayer = sent.systems().get("S1").layers().get(0);
+        SystemSnapshot system = sent.systems().get("S1");
+        SystemSnapshot.LayerSnapshot sentLayer = system.layers().get(0);
         assertEquals(6.0, sentLayer.water().dissolvedOxygen().average());
         assertEquals(1.0, sentLayer.actuators().airPump().average());
         assertNotNull(sentLayer.lastUpdate());
+        assertEquals(1.0, system.actuators().airPump().average());
     }
 }
 

--- a/src/test/java/se/hydroleaf/service/StatusServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/StatusServiceTest.java
@@ -148,8 +148,8 @@ class StatusServiceTest {
         }).when(statusService).getAverage(anyString(), anyString(), anyString());
 
         LiveNowSnapshot result = statusService.getLiveNowSnapshot();
-
-        List<SystemSnapshot.LayerSnapshot> s01Layers = result.systems().get("S01").layers();
+        SystemSnapshot s01System = result.systems().get("S01");
+        List<SystemSnapshot.LayerSnapshot> s01Layers = s01System.layers();
         assertEquals(1, s01Layers.size());
         SystemSnapshot.LayerSnapshot s01Layer = s01Layers.get(0);
         SystemSnapshot.LayerSnapshot s02Layer = result.systems().get("S02").layers().get(0);
@@ -157,6 +157,9 @@ class StatusServiceTest {
         assertEquals(light, s01Layer.environment().light());
         assertEquals(dOxy, s02Layer.water().dissolvedOxygen());
         assertNotNull(s01Layer.lastUpdate());
+        assertEquals(pump, s01System.actuators().airPump());
+        assertEquals(light, s01System.environment().light());
+        assertEquals(dOxy, result.systems().get("S02").water().dissolvedOxygen());
 
         verify(statusService, times(1)).getAverage("S01", "L01", "airPump");
         verify(statusService, times(1)).getAverage("S01", "L01", "light");
@@ -181,11 +184,13 @@ class StatusServiceTest {
         LiveNowSnapshot result = statusService.getLiveNowSnapshot();
 
         assertEquals(1, result.systems().size());
-        List<SystemSnapshot.LayerSnapshot> layers = result.systems().get("S01").layers();
+        SystemSnapshot system = result.systems().get("S01");
+        List<SystemSnapshot.LayerSnapshot> layers = system.layers();
         assertEquals(1, layers.size());
         SystemSnapshot.LayerSnapshot layerSnapshot = layers.get(0);
         assertEquals(pump, layerSnapshot.actuators().airPump());
         assertNotNull(layerSnapshot.lastUpdate());
+        assertEquals(pump, system.actuators().airPump());
         verify(statusService, atLeastOnce()).getAverage("S01", "L01", "airPump");
     }
 


### PR DESCRIPTION
## Summary
- expand `SystemSnapshot` to include system-level last update, actuators, water, and environment
- aggregate layer data into new system fields in `StatusService#getLiveNowSnapshot`
- expose `/api/status/live-now` endpoint and update tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f3afa79a08328bc355797bca8875d