### PR TITLE
Rename airTemperature to temperature and add history test

### DIFF
--- a/src/main/java/se/hydroleaf/dto/GrowSensorSummary.java
+++ b/src/main/java/se/hydroleaf/dto/GrowSensorSummary.java
@@ -3,5 +3,5 @@ package se.hydroleaf.dto;
 public record GrowSensorSummary(
         StatusAverageResponse light,
         StatusAverageResponse humidity,
-        StatusAverageResponse airTemperature
+        StatusAverageResponse temperature
 ) {}

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -58,7 +58,7 @@ public class StatusService {
         List<String> sensorTypes = List.of(
                 "light",
                 "humidity",
-                "airTemperature",
+                "temperature",
                 "dissolvedOxygen",
                 "dissolvedTemp",
                 "pH",
@@ -73,7 +73,7 @@ public class StatusService {
         Map<String, StatusAverageResponse> growSensors = Map.of(
                 "light", responses.get("light"),
                 "humidity", responses.get("humidity"),
-                "airTemperature", responses.get("airTemperature")
+                "temperature", responses.get("temperature")
         );
         Map<String, StatusAverageResponse> waterTank = Map.ofEntries(
                 Map.entry("dissolvedTemp", responses.get("dissolvedTemp")),
@@ -109,7 +109,7 @@ public class StatusService {
                 GrowSensorSummary environment = new GrowSensorSummary(
                         getAverage(system, layer, "light"),
                         getAverage(system, layer, "humidity"),
-                        getAverage(system, layer, "airTemperature")
+                        getAverage(system, layer, "temperature")
                 );
                 WaterTankSummary water = new WaterTankSummary(
                         getAverage(system, layer, "dissolvedTemp"),
@@ -148,7 +148,7 @@ public class StatusService {
             GrowSensorSummary environment = new GrowSensorSummary(
                     aggregate(layers, l -> l.environment().light()),
                     aggregate(layers, l -> l.environment().humidity()),
-                    aggregate(layers, l -> l.environment().airTemperature())
+                    aggregate(layers, l -> l.environment().temperature())
             );
             result.put(entry.getKey(), new SystemSnapshot(lastUpdate, actuators, water, environment, layers));
         }
@@ -191,7 +191,7 @@ public class StatusService {
         return switch (sensorType.toLowerCase()) {
             case "light" -> "lux";
             case "humidity" -> "%";
-            case "airtemperature", "dissolvedtemp" -> "°C";
+            case "temperature", "dissolvedtemp" -> "°C";
             case "dissolvedoxygen" -> "mg/L";
             case "ph" -> "pH";
             case "dissolvedec" -> "mS/cm";

--- a/src/test/java/se/hydroleaf/controller/SensorRecordControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/SensorRecordControllerTest.java
@@ -1,0 +1,56 @@
+package se.hydroleaf.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import se.hydroleaf.dto.*;
+import se.hydroleaf.service.RecordService;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class SensorRecordControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RecordService recordService;
+
+    @Test
+    void aggregatedHistoryReturnsTemperatureData() throws Exception {
+        AggregatedSensorData tempData = new AggregatedSensorData(
+                "temperature",
+                "°C",
+                List.of(new TimestampValue(Instant.parse("2023-01-01T00:00:00Z"), 25.0))
+        );
+        AggregatedHistoryResponse response = new AggregatedHistoryResponse(
+                Instant.parse("2023-01-01T00:00:00Z"),
+                Instant.parse("2023-01-02T00:00:00Z"),
+                List.of(tempData)
+        );
+        when(recordService.aggregatedHistory(eq("dev1"), any(), any(), eq("5m"))).thenReturn(response);
+
+        mockMvc.perform(get("/api/records/history/aggregated")
+                        .param("compositeId", "dev1")
+                        .param("from", "2023-01-01T00:00:00Z")
+                        .param("to", "2023-01-02T00:00:00Z")
+                        .param("bucket", "5m"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sensors[0].sensorType").value("temperature"))
+                .andExpect(jsonPath("$.sensors[0].data[0].value").value(25.0));
+    }
+}

--- a/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
@@ -77,7 +77,7 @@ class StatusControllerTest {
         Map<String, StatusAverageResponse> growSensors = Map.of(
                 "light", new StatusAverageResponse(1.0, "lux",1L),
                 "humidity", new StatusAverageResponse(2.0, "%",2L),
-                "airTemperature", new StatusAverageResponse(3.0, "°C",3L)
+                "temperature", new StatusAverageResponse(3.0, "°C",3L)
         );
         Map<String, StatusAverageResponse> waterTank = Map.of(
                 "dissolvedTemp", new StatusAverageResponse(4.0, "°C",4L),
@@ -97,7 +97,7 @@ class StatusControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.growSensors.light.average").value(1.0))
                 .andExpect(jsonPath("$.growSensors.humidity.average").value(2.0))
-                .andExpect(jsonPath("$.growSensors.airTemperature.average").value(3.0))
+                .andExpect(jsonPath("$.growSensors.temperature.average").value(3.0))
                 .andExpect(jsonPath("$.waterTank.dissolvedTemp.average").value(4.0))
                 .andExpect(jsonPath("$.waterTank.dissolvedOxygen.average").value(5.0))
                 .andExpect(jsonPath("$.waterTank.pH.average").value(6.0))
@@ -148,6 +148,8 @@ class StatusControllerTest {
         mockMvc.perform(get("/api/status/live-now"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.systems.sys.actuators.airPump.average").value(1.0))
+                .andExpect(jsonPath("$.systems.sys.environment.temperature.average").value(8.0))
+                .andExpect(jsonPath("$.systems.sys.layers[0].environment.temperature.average").value(8.0))
                 .andExpect(jsonPath("$.systems.sys.layers[0].water.dissolvedOxygen.average").value(5.0));
     }
 }

--- a/src/test/java/se/hydroleaf/service/StatusServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/StatusServiceTest.java
@@ -87,7 +87,7 @@ class StatusServiceTest {
                 .thenReturn(simpleResult(1.0, 1L));
         when(sensorDataRepository.getLatestAverage("sys", "layer", "humidity"))
                 .thenReturn(simpleResult(2.0, 2L));
-        when(sensorDataRepository.getLatestAverage("sys", "layer", "airTemperature"))
+        when(sensorDataRepository.getLatestAverage("sys", "layer", "temperature"))
                 .thenReturn(simpleResult(3.0, 3L));
         when(sensorDataRepository.getLatestAverage("sys", "layer", "dissolvedOxygen"))
                 .thenReturn(simpleResult(4.0, 4L));
@@ -106,7 +106,7 @@ class StatusServiceTest {
 
         assertEquals(1.0, response.growSensors().get("light").average());
         assertEquals(2.0, response.growSensors().get("humidity").average());
-        assertEquals(3.0, response.growSensors().get("airTemperature").average());
+        assertEquals(3.0, response.growSensors().get("temperature").average());
         assertEquals(5.0, response.waterTank().get("dissolvedTemp").average());
         assertEquals(4.0, response.waterTank().get("dissolvedOxygen").average());
         assertEquals(6.0, response.waterTank().get("pH").average());
@@ -143,7 +143,7 @@ class StatusServiceTest {
                 case "airPump" -> pump;
                 case "light" -> light;
                 case "humidity" -> humidity;
-                case "airTemperature" -> temp;
+                case "temperature" -> temp;
                 case "dissolvedTemp" -> dTemp;
                 case "dissolvedOxygen" -> dOxy;
                 case "pH" -> dPh;


### PR DESCRIPTION
## Summary
- rename `airTemperature` sensor to `temperature` throughout service and DTOs
- update controller and service tests for new field name
- add history endpoint test covering temperature readings

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f740d8e248328bd84e634e78df880