### PR TITLE
Start MQTT service after application ready event

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttService.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttService.java
@@ -1,10 +1,11 @@
 package se.hydroleaf.mqtt;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.paho.client.mqttv3.*;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
@@ -28,9 +29,13 @@ public class MqttService implements MqttCallback {
         this.messageHandler = messageHandler;
     }
 
-    @PostConstruct
     public void start() throws Exception {
         clientManager.start(this);
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() throws Exception {
+        start();
     }
 
     @PreDestroy


### PR DESCRIPTION
## Summary
- Initialize MqttService after the Spring context is fully ready using ApplicationReadyEvent
- Remove PostConstruct in favour of an explicit start method triggered on application startup

## Testing
- `mvn -q spring-boot:run -Dspring-boot.run.arguments="--mqtt.enabled=true --mqtt.brokerUri=tcp://localhost:1884"` *(fails: Non-resolvable parent POM for se.hydroleaf:demo:0.0.1-SNAPSHOT: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f853279dc8328a894fce9f6ea0b84