### PR TITLE
Disable Open Session in View and enforce transactional data loading

### DIFF
--- a/src/main/java/se/hydroleaf/repository/SensorRecordRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorRecordRepository.java
@@ -1,5 +1,6 @@
 package se.hydroleaf.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import se.hydroleaf.model.SensorRecord;
 
@@ -7,5 +8,7 @@ import java.time.Instant;
 import java.util.List;
 
 public interface SensorRecordRepository extends JpaRepository<SensorRecord, Long> {
+
+    @EntityGraph(attributePaths = {"values", "healthItems"})
     List<SensorRecord> findByDevice_CompositeIdAndTimestampBetween(String compositeId, Instant from, Instant to);
 }

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -2,6 +2,7 @@ package se.hydroleaf.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import se.hydroleaf.dto.LiveNowSnapshot;
 import se.hydroleaf.dto.LayerActuatorStatus;
 import se.hydroleaf.dto.GrowSensorSummary;
@@ -26,6 +27,7 @@ import java.util.function.Function;
 
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 public class StatusService {
 
     private final SensorDataRepository sensorDataRepository;

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -14,6 +14,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: false
+    open-in-view: false
 
 mqtt:
   brokerUri: ${MQTT_BROKER:tcp://192.168.8.3:1883}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: false
+    open-in-view: false
   flyway:
     enabled: false
     baseline-on-migrate: true


### PR DESCRIPTION
## Summary
- disable Spring's Open Session in View to limit session scope
- fetch SensorRecord children eagerly and wrap StatusService in read-only transactions

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_689f866a88e8832892f9ac28367679d0