### PR TITLE
Handle waterTank topics without composite_id

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
@@ -80,9 +80,16 @@ public class MqttMessageHandler {
     private static final Pattern GROW_PATTERN =
             Pattern.compile("^growSensors/(S\\d+)/(L\\d+)/([^/]+)$");
 
+    private static final Pattern WATER_PATTERN =
+            Pattern.compile("^waterTank/(S\\d+)/(L\\d+)/([^/]+)$");
+
     private String deriveCompositeIdFromTopic(String topic) {
         if (topic == null) return null;
         Matcher m = GROW_PATTERN.matcher(topic);
+        if (m.find()) {
+            return m.group(1) + "-" + m.group(2) + "-" + m.group(3);
+        }
+        m = WATER_PATTERN.matcher(topic);
         if (m.find()) {
             return m.group(1) + "-" + m.group(2) + "-" + m.group(3);
         }

--- a/src/test/java/se/hydroleaf/mqtt/MqttMessageHandlerWaterTankTest.java
+++ b/src/test/java/se/hydroleaf/mqtt/MqttMessageHandlerWaterTankTest.java
@@ -1,0 +1,53 @@
+package se.hydroleaf.mqtt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import se.hydroleaf.service.DeviceProvisionService;
+import se.hydroleaf.service.RecordService;
+
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MqttMessageHandlerWaterTankTest {
+
+    @Mock
+    RecordService recordService;
+    @Mock
+    SimpMessagingTemplate messagingTemplate;
+    @Mock
+    DeviceProvisionService deviceProvisionService;
+
+    ObjectMapper objectMapper;
+    ConcurrentHashMap<String, Instant> lastSeen;
+    MqttMessageHandler handler;
+
+    @BeforeEach
+    void setup() {
+        objectMapper = new ObjectMapper();
+        lastSeen = new ConcurrentHashMap<>();
+        handler = new MqttMessageHandler(false, objectMapper, recordService, messagingTemplate, deviceProvisionService, lastSeen);
+    }
+
+    @Test
+    void waterTankTopicWithoutCompositeId_isProcessed() {
+        String topic = "waterTank/S01/L01/probe1";
+        String payload = "{}";
+
+        handler.handle(topic, payload);
+
+        verify(deviceProvisionService).ensureDevice(eq("S01-L01-probe1"), eq(topic));
+        verify(recordService).saveRecord(eq("S01-L01-probe1"), any());
+        assertTrue(lastSeen.containsKey("S01-L01-probe1"));
+    }
+}


### PR DESCRIPTION
## Summary
- Extend MQTT handler to derive composite IDs from `waterTank` topics
- Add unit test ensuring `waterTank` messages without `composite_id` are processed

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f87be46cc832882727e0a21e45d85