### PR TITLE
Ignore base MQTT topics without composite ID

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
@@ -58,7 +58,11 @@ public class MqttMessageHandler {
                 compositeId = deriveCompositeIdFromTopic(topic);
             }
             if (compositeId == null || compositeId.isBlank()) {
-                log.warn("MQTT parse/handle failed on topic {}: missing composite_id", topic);
+                if (topic == null || !topic.contains("/")) {
+                    log.debug("Ignoring MQTT message on topic {} without composite_id", topic);
+                } else {
+                    log.warn("MQTT parse/handle failed on topic {}: missing composite_id", topic);
+                }
                 return;
             }
 

--- a/src/test/java/se/hydroleaf/mqtt/MqttMessageHandlerWaterTankTest.java
+++ b/src/test/java/se/hydroleaf/mqtt/MqttMessageHandlerWaterTankTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class MqttMessageHandlerWaterTankTest {
@@ -49,5 +50,16 @@ class MqttMessageHandlerWaterTankTest {
         verify(deviceProvisionService).ensureDevice(eq("S01-L01-probe1"), eq(topic));
         verify(recordService).saveRecord(eq("S01-L01-probe1"), any());
         assertTrue(lastSeen.containsKey("S01-L01-probe1"));
+    }
+
+    @Test
+    void waterTankBaseTopicWithoutCompositeId_isIgnored() {
+        String topic = "waterTank";
+        String payload = "{}";
+
+        handler.handle(topic, payload);
+
+        verifyNoInteractions(deviceProvisionService, recordService);
+        assertTrue(lastSeen.isEmpty());
     }
 }


### PR DESCRIPTION
## Summary
- avoid warning on root MQTT topics that lack composite IDs
- ensure base `waterTank` topics are ignored via unit test

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f9107b36883289a39cc1e39cfbb0c