### PR TITLE
Add LatestSensorValue entity and repository

### DIFF
--- a/src/main/java/se/hydroleaf/model/LatestSensorValue.java
+++ b/src/main/java/se/hydroleaf/model/LatestSensorValue.java
@@ -1,0 +1,46 @@
+package se.hydroleaf.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "latest_sensor_value",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "ux_lsv_device_sensor", columnNames = {"composite_id", "sensor_type"})
+        },
+        indexes = {
+                @Index(name = "ix_lsv_sensor_device", columnList = "sensor_type, composite_id")
+        }
+)
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LatestSensorValue {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "composite_id", referencedColumnName = "composite_id", nullable = false)
+    private Device device;
+
+    @Column(name = "sensor_type", nullable = false)
+    private String sensorType;
+
+    @Column(name = "value")
+    private Double value;
+
+    @Column(name = "unit")
+    private String unit;
+
+    @Column(name = "value_time", nullable = false)
+    private Instant timestamp;
+}

--- a/src/main/java/se/hydroleaf/repository/LatestSensorValueRepository.java
+++ b/src/main/java/se/hydroleaf/repository/LatestSensorValueRepository.java
@@ -1,0 +1,28 @@
+package se.hydroleaf.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import se.hydroleaf.model.LatestSensorValue;
+
+import java.util.Optional;
+
+@Repository
+public interface LatestSensorValueRepository extends JpaRepository<LatestSensorValue, Long> {
+
+    Optional<LatestSensorValue> findByDeviceCompositeIdAndSensorType(String compositeId, String sensorType);
+
+    @Query(value = """
+            SELECT COALESCE(AVG(l.value),0) AS average,
+                   COUNT(*)                AS count
+            FROM latest_sensor_value l
+            JOIN device d ON d.composite_id = l.composite_id
+            WHERE d.system = :system
+              AND d.layer = :layer
+              AND l.sensor_type = :sensorType
+            """, nativeQuery = true)
+    AverageResult getLatestSensorAverage(@Param("system") String system,
+                                         @Param("layer") String layer,
+                                         @Param("sensorType") String sensorType);
+}

--- a/src/main/resources/db/migration/V2__add_latest_sensor_value.sql
+++ b/src/main/resources/db/migration/V2__add_latest_sensor_value.sql
@@ -1,0 +1,12 @@
+CREATE TABLE latest_sensor_value (
+    id BIGSERIAL PRIMARY KEY,
+    composite_id VARCHAR(128) NOT NULL,
+    sensor_type VARCHAR(64) NOT NULL,
+    value DOUBLE PRECISION,
+    unit VARCHAR(32),
+    value_time TIMESTAMPTZ NOT NULL,
+    CONSTRAINT fk_lsv_device FOREIGN KEY (composite_id) REFERENCES device(composite_id),
+    CONSTRAINT ux_lsv_device_sensor UNIQUE (composite_id, sensor_type)
+);
+
+CREATE INDEX ix_lsv_sensor_device ON latest_sensor_value (sensor_type, composite_id);


### PR DESCRIPTION
## Summary
- add `LatestSensorValue` JPA entity with unique constraint and index for latest readings per device and sensor type
- implement `LatestSensorValueRepository` with lookup and aggregation methods
- introduce Flyway migration creating `latest_sensor_value` table and constraints

## Testing
- `./mvnw -q test` *(failed: wget unable to fetch Maven wrapper)*
- `mvn -q test` *(failed: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a02235d0808328af470ce6726455d8