### PR TITLE
Add LatestActuatorStatus entity and repository

### DIFF
--- a/src/main/java/se/hydroleaf/model/LatestActuatorStatus.java
+++ b/src/main/java/se/hydroleaf/model/LatestActuatorStatus.java
@@ -1,0 +1,44 @@
+package se.hydroleaf.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(
+        name = "latest_actuator_status",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "ux_las_device_actuator", columnNames = {"composite_id", "actuator_type"})
+        },
+        indexes = {
+                @Index(name = "ix_las_actuator_device", columnList = "actuator_type, composite_id")
+        }
+)
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LatestActuatorStatus {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "composite_id", referencedColumnName = "composite_id", nullable = false)
+    private Device device;
+
+    @Column(name = "actuator_type", nullable = false)
+    private String actuatorType;
+
+    @Column(name = "state", nullable = false)
+    private Boolean state;
+
+    @Column(name = "status_time", nullable = false)
+    private Instant timestamp;
+}
+

--- a/src/main/java/se/hydroleaf/repository/LatestActuatorStatusRepository.java
+++ b/src/main/java/se/hydroleaf/repository/LatestActuatorStatusRepository.java
@@ -1,0 +1,27 @@
+package se.hydroleaf.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import se.hydroleaf.model.LatestActuatorStatus;
+
+import java.util.Optional;
+
+@Repository
+public interface LatestActuatorStatusRepository extends JpaRepository<LatestActuatorStatus, Long> {
+
+    Optional<LatestActuatorStatus> findByDeviceCompositeIdAndActuatorType(String compositeId, String actuatorType);
+
+    @Query(value = """
+            SELECT l.state FROM latest_actuator_status l
+            JOIN device d ON d.composite_id = l.composite_id
+            WHERE d.system = :system
+              AND d.layer = :layer
+              AND l.actuator_type = :actuatorType
+            LIMIT 1
+            """, nativeQuery = true)
+    Boolean getLatestActuatorState(@Param("system") String system,
+                                   @Param("layer") String layer,
+                                   @Param("actuatorType") String actuatorType);
+}

--- a/src/main/resources/db/migration/V3__add_latest_actuator_status.sql
+++ b/src/main/resources/db/migration/V3__add_latest_actuator_status.sql
@@ -1,0 +1,11 @@
+CREATE TABLE latest_actuator_status (
+    id BIGSERIAL PRIMARY KEY,
+    composite_id VARCHAR(128) NOT NULL,
+    actuator_type VARCHAR(64) NOT NULL,
+    state BOOLEAN NOT NULL,
+    status_time TIMESTAMPTZ NOT NULL,
+    CONSTRAINT fk_las_device FOREIGN KEY (composite_id) REFERENCES device(composite_id),
+    CONSTRAINT ux_las_device_actuator UNIQUE (composite_id, actuator_type)
+);
+
+CREATE INDEX ix_las_actuator_device ON latest_actuator_status (actuator_type, composite_id);


### PR DESCRIPTION
## Summary
- add LatestActuatorStatus entity and JPA repository
- create Flyway migration for latest_actuator_status table

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a025391778832891d39bf52b71c0c2