### PR TITLE
Upsert latest sensor and actuator states

### DIFF
--- a/src/main/java/se/hydroleaf/model/LatestSensorValue.java
+++ b/src/main/java/se/hydroleaf/model/LatestSensorValue.java
@@ -35,7 +35,7 @@ public class LatestSensorValue {
     @Column(name = "sensor_type", nullable = false)
     private String sensorType;
 
-    @Column(name = "value")
+    @Column(name = "sensor_value")
     private Double value;
 
     @Column(name = "unit")

--- a/src/main/java/se/hydroleaf/repository/LatestSensorValueRepository.java
+++ b/src/main/java/se/hydroleaf/repository/LatestSensorValueRepository.java
@@ -14,7 +14,7 @@ public interface LatestSensorValueRepository extends JpaRepository<LatestSensorV
     Optional<LatestSensorValue> findByDeviceCompositeIdAndSensorType(String compositeId, String sensorType);
 
     @Query(value = """
-            SELECT COALESCE(AVG(l.value),0) AS average,
+            SELECT COALESCE(AVG(l.sensor_value),0) AS average,
                    COUNT(*)                AS count
             FROM latest_sensor_value l
             JOIN device d ON d.composite_id = l.composite_id

--- a/src/main/java/se/hydroleaf/service/ActuatorService.java
+++ b/src/main/java/se/hydroleaf/service/ActuatorService.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import se.hydroleaf.model.Device;
 import se.hydroleaf.model.ActuatorStatus;
+import se.hydroleaf.model.LatestActuatorStatus;
 import se.hydroleaf.repository.DeviceRepository;
 import se.hydroleaf.repository.ActuatorStatusRepository;
+import se.hydroleaf.repository.LatestActuatorStatusRepository;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -27,13 +29,16 @@ public class ActuatorService {
     private final ObjectMapper objectMapper;
     private final ActuatorStatusRepository actuatorRepo;
     private final DeviceRepository deviceRepo;
+    private final LatestActuatorStatusRepository latestActuatorRepo;
 
     public ActuatorService(ObjectMapper objectMapper,
                            ActuatorStatusRepository actuatorRepo,
-                           DeviceRepository deviceRepo) {
+                           DeviceRepository deviceRepo,
+                           LatestActuatorStatusRepository latestActuatorRepo) {
         this.objectMapper = objectMapper;
         this.actuatorRepo = actuatorRepo;
         this.deviceRepo = deviceRepo;
+        this.latestActuatorRepo = latestActuatorRepo;
     }
 
     /** Entry point used by tests and other layers. */
@@ -76,6 +81,18 @@ public class ActuatorService {
                     row.setActuatorType(name);
                     row.setState(status);
                     actuatorRepo.save(row);
+                    // Upsert latest actuator status
+                    LatestActuatorStatus latest = latestActuatorRepo
+                            .findByDeviceCompositeIdAndActuatorType(device.getCompositeId(), name)
+                            .orElseGet(() -> {
+                                LatestActuatorStatus l = new LatestActuatorStatus();
+                                l.setDevice(device);
+                                l.setActuatorType(name);
+                                return l;
+                            });
+                    latest.setState(status);
+                    latest.setTimestamp(ts);
+                    latestActuatorRepo.save(latest);
                     savedAny = true;
                 }
             }

--- a/src/main/resources/db/migration/V2__add_latest_sensor_value.sql
+++ b/src/main/resources/db/migration/V2__add_latest_sensor_value.sql
@@ -2,7 +2,7 @@ CREATE TABLE latest_sensor_value (
     id BIGSERIAL PRIMARY KEY,
     composite_id VARCHAR(128) NOT NULL,
     sensor_type VARCHAR(64) NOT NULL,
-    value DOUBLE PRECISION,
+    sensor_value DOUBLE PRECISION,
     unit VARCHAR(32),
     value_time TIMESTAMPTZ NOT NULL,
     CONSTRAINT fk_lsv_device FOREIGN KEY (composite_id) REFERENCES device(composite_id),

--- a/src/test/java/se/hydroleaf/service/RecordServiceLatestTests.java
+++ b/src/test/java/se/hydroleaf/service/RecordServiceLatestTests.java
@@ -1,0 +1,107 @@
+package se.hydroleaf.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import se.hydroleaf.model.Device;
+import se.hydroleaf.model.DeviceGroup;
+import se.hydroleaf.model.LatestActuatorStatus;
+import se.hydroleaf.model.LatestSensorValue;
+import se.hydroleaf.repository.DeviceGroupRepository;
+import se.hydroleaf.repository.DeviceRepository;
+import se.hydroleaf.repository.LatestActuatorStatusRepository;
+import se.hydroleaf.repository.LatestSensorValueRepository;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Integration tests verifying that RecordService upserts latest tables. */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class RecordServiceLatestTests {
+
+    @Autowired ObjectMapper objectMapper;
+    @Autowired RecordService recordService;
+    @Autowired DeviceRepository deviceRepository;
+    @Autowired DeviceGroupRepository deviceGroupRepository;
+    @Autowired LatestSensorValueRepository latestSensorValueRepository;
+    @Autowired LatestActuatorStatusRepository latestActuatorStatusRepository;
+
+    private DeviceGroup ensureGroup() {
+        return deviceGroupRepository.findByMqttTopic("test-group").orElseGet(() -> {
+            DeviceGroup g = new DeviceGroup();
+            g.setMqttTopic("test-group");
+            return deviceGroupRepository.save(g);
+        });
+    }
+
+    private Device ensureDevice(String compositeId) {
+        return deviceRepository.findById(compositeId).orElseGet(() -> {
+            Device d = new Device();
+            d.setCompositeId(compositeId);
+            String[] parts = compositeId.split("-");
+            if (parts.length >= 2) {
+                d.setSystem(parts[0]);
+                d.setLayer(parts[1]);
+                d.setDeviceId(parts[2]);
+            }
+            d.setGroup(ensureGroup());
+            return deviceRepository.save(d);
+        });
+    }
+
+    @Test
+    void upserts_latest_sensor_and_actuator() throws Exception {
+        String compositeId = "S05-L01-T01";
+        ensureDevice(compositeId);
+
+        String first = """
+                {
+                  "timestamp":"2024-01-01T00:00:00Z",
+                  "sensors":[{"sensorName":"lightSensor","sensorType":"light","value":10.0,"unit":"lx"}],
+                  "controllers":[{"name":"airPump","state":true}]
+                }
+                """;
+        recordService.saveRecord(compositeId, objectMapper.readTree(first));
+
+        LatestSensorValue lsv = latestSensorValueRepository
+                .findByDeviceCompositeIdAndSensorType(compositeId, "light")
+                .orElseThrow();
+        assertEquals(10.0, lsv.getValue());
+        assertEquals("lx", lsv.getUnit());
+        assertEquals(Instant.parse("2024-01-01T00:00:00Z"), lsv.getTimestamp());
+
+        LatestActuatorStatus las = latestActuatorStatusRepository
+                .findByDeviceCompositeIdAndActuatorType(compositeId, "airPump")
+                .orElseThrow();
+        assertTrue(las.getState());
+        assertEquals(Instant.parse("2024-01-01T00:00:00Z"), las.getTimestamp());
+
+        String second = """
+                {
+                  "timestamp":"2024-01-01T00:05:00Z",
+                  "sensors":[{"sensorName":"lightSensor","sensorType":"light","value":15.5,"unit":"lx"}],
+                  "controllers":[{"name":"airPump","state":false}]
+                }
+                """;
+        recordService.saveRecord(compositeId, objectMapper.readTree(second));
+
+        LatestSensorValue lsv2 = latestSensorValueRepository
+                .findByDeviceCompositeIdAndSensorType(compositeId, "light")
+                .orElseThrow();
+        assertEquals(15.5, lsv2.getValue());
+        assertEquals(Instant.parse("2024-01-01T00:05:00Z"), lsv2.getTimestamp());
+
+        LatestActuatorStatus las2 = latestActuatorStatusRepository
+                .findByDeviceCompositeIdAndActuatorType(compositeId, "airPump")
+                .orElseThrow();
+        assertFalse(las2.getState());
+        assertEquals(Instant.parse("2024-01-01T00:05:00Z"), las2.getTimestamp());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Track most recent sensor readings per device and sensor type by upserting `latest_sensor_value` when saving records
- Maintain latest actuator states when saving records or actuator payloads by upserting `latest_actuator_status`
- Add integration tests verifying latest sensor and actuator upserts

## Testing
- `./mvnw -q -e test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*


------
https://chatgpt.com/codex/tasks/task_e_68a026d56b6483289c6a435ac4308206