### PR TITLE
refactor: consolidate actuator status DTO

### DIFF
--- a/src/main/java/se/hydroleaf/dto/ActuatorStatusSummary.java
+++ b/src/main/java/se/hydroleaf/dto/ActuatorStatusSummary.java
@@ -1,5 +1,5 @@
 package se.hydroleaf.dto;
 
-public record SystemActuatorStatus(
+public record ActuatorStatusSummary(
         StatusAverageResponse airPump
 ) {}

--- a/src/main/java/se/hydroleaf/dto/LayerActuatorStatus.java
+++ b/src/main/java/se/hydroleaf/dto/LayerActuatorStatus.java
@@ -1,5 +1,0 @@
-package se.hydroleaf.dto;
-
-public record LayerActuatorStatus(
-        StatusAverageResponse airPump
-) {}

--- a/src/main/java/se/hydroleaf/dto/SystemSnapshot.java
+++ b/src/main/java/se/hydroleaf/dto/SystemSnapshot.java
@@ -8,7 +8,7 @@ import java.util.List;
  */
 public record SystemSnapshot(
         Instant lastUpdate,
-        SystemActuatorStatus actuators,
+        ActuatorStatusSummary actuators,
         WaterTankSummary water,
         GrowSensorSummary environment,
         List<LayerSnapshot> layers
@@ -21,7 +21,7 @@ public record SystemSnapshot(
     public record LayerSnapshot(
             String layerId,
             Instant lastUpdate,
-            LayerActuatorStatus actuators,
+            ActuatorStatusSummary actuators,
             WaterTankSummary water,
             GrowSensorSummary environment
     ) {}

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -3,12 +3,11 @@ package se.hydroleaf.service;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import se.hydroleaf.dto.ActuatorStatusSummary;
 import se.hydroleaf.dto.LiveNowSnapshot;
-import se.hydroleaf.dto.LayerActuatorStatus;
 import se.hydroleaf.dto.GrowSensorSummary;
 import se.hydroleaf.dto.SystemSnapshot;
 import se.hydroleaf.dto.WaterTankSummary;
-import se.hydroleaf.dto.SystemActuatorStatus;
 import se.hydroleaf.dto.StatusAllAverageResponse;
 import se.hydroleaf.dto.StatusAverageResponse;
 import se.hydroleaf.model.Device;
@@ -111,7 +110,7 @@ public class StatusService {
 
             Map<String, SystemSnapshot.LayerSnapshot> layers = systemLayers.computeIfAbsent(system, s -> new HashMap<>());
             layers.computeIfAbsent(layer, l -> {
-                LayerActuatorStatus actuator = new LayerActuatorStatus(getAverage(system, layer, "airPump"));
+                  ActuatorStatusSummary actuator = new ActuatorStatusSummary(getAverage(system, layer, "airPump"));
                 GrowSensorSummary environment = new GrowSensorSummary(
                         getAverage(system, layer, "light"),
                         getAverage(system, layer, "humidity"),
@@ -142,8 +141,8 @@ public class StatusService {
                     .map(SystemSnapshot.LayerSnapshot::lastUpdate)
                     .max(Comparator.naturalOrder())
                     .orElse(null);
-            StatusAverageResponse airPump = aggregate(layers, l -> l.actuators().airPump());
-            SystemActuatorStatus actuators = new SystemActuatorStatus(airPump);
+              StatusAverageResponse airPump = aggregate(layers, l -> l.actuators().airPump());
+              ActuatorStatusSummary actuators = new ActuatorStatusSummary(airPump);
             WaterTankSummary water = new WaterTankSummary(
                     aggregate(layers, l -> l.water().dissolvedTemp()),
                     aggregate(layers, l -> l.water().dissolvedOxygen()),

--- a/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
@@ -111,7 +111,7 @@ class StatusControllerTest {
         SystemSnapshot.LayerSnapshot layer = new SystemSnapshot.LayerSnapshot(
                 "L1",
                 java.time.Instant.parse("2023-01-01T00:00:00Z"),
-                new LayerActuatorStatus(new StatusAverageResponse(1.0, "status", 1L)),
+                new ActuatorStatusSummary(new StatusAverageResponse(1.0, "status", 1L)),
                 new WaterTankSummary(
                         new StatusAverageResponse(4.0, "°C",1L),
                         new StatusAverageResponse(5.0, "mg/L",1L),
@@ -127,7 +127,7 @@ class StatusControllerTest {
         );
         SystemSnapshot system = new SystemSnapshot(
                 java.time.Instant.parse("2023-01-01T00:00:00Z"),
-                new SystemActuatorStatus(new StatusAverageResponse(1.0, "status",1L)),
+                new ActuatorStatusSummary(new StatusAverageResponse(1.0, "status",1L)),
                 new WaterTankSummary(
                         new StatusAverageResponse(4.0, "°C",1L),
                         new StatusAverageResponse(5.0, "mg/L",1L),

--- a/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
+++ b/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
@@ -37,7 +37,7 @@ class LiveFeedSchedulerTest {
         SystemSnapshot.LayerSnapshot layerSnapshot = new SystemSnapshot.LayerSnapshot(
                 "L1",
                 java.time.Instant.now(),
-                new LayerActuatorStatus(new StatusAverageResponse(1.0, "status", 1L)),
+                  new ActuatorStatusSummary(new StatusAverageResponse(1.0, "status", 1L)),
                 new WaterTankSummary(
                         new StatusAverageResponse(5.0, "°C", 1L),
                         new StatusAverageResponse(6.0, "mg/L", 1L),
@@ -53,7 +53,7 @@ class LiveFeedSchedulerTest {
         );
         SystemSnapshot systemSnapshot = new SystemSnapshot(
                 java.time.Instant.now(),
-                new SystemActuatorStatus(new StatusAverageResponse(1.0, "status", 1L)),
+                  new ActuatorStatusSummary(new StatusAverageResponse(1.0, "status", 1L)),
                 new WaterTankSummary(
                         new StatusAverageResponse(5.0, "°C", 1L),
                         new StatusAverageResponse(6.0, "mg/L", 1L),


### PR DESCRIPTION
## Summary
- replace separate SystemActuatorStatus and LayerActuatorStatus with unified ActuatorStatusSummary DTO
- update status service, snapshot model, and tests to use the new DTO
- remove obsolete actuator status DTO classes

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a031d31cf88328af26820a695c5ad3