### PR TITLE
Replace Lombok @Data on entities

### DIFF
--- a/src/main/java/se/hydroleaf/model/ActuatorStatus.java
+++ b/src/main/java/se/hydroleaf/model/ActuatorStatus.java
@@ -3,8 +3,11 @@ package se.hydroleaf.model;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.time.Instant;
 
@@ -16,7 +19,10 @@ import java.time.Instant;
         indexes = {
                 @Index(name = "ix_as_device_time", columnList = "composite_id, status_time DESC")
         })
-@Data
+@Getter
+@Setter
+@EqualsAndHashCode(exclude = "device")
+@ToString(exclude = "device")
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/se/hydroleaf/model/Device.java
+++ b/src/main/java/se/hydroleaf/model/Device.java
@@ -3,14 +3,20 @@ package se.hydroleaf.model;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
+@Getter
+@Setter
+@EqualsAndHashCode(exclude = "group")
+@ToString(exclude = "group")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Data
 @Table(
         name = "device",
         uniqueConstraints = {

--- a/src/main/java/se/hydroleaf/model/DeviceGroup.java
+++ b/src/main/java/se/hydroleaf/model/DeviceGroup.java
@@ -3,8 +3,11 @@ package se.hydroleaf.model;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(
@@ -13,10 +16,13 @@ import lombok.NoArgsConstructor;
                 @Index(name = "ux_device_group_mqtt_topic", columnList = "mqtt_topic", unique = true)
         }
 )
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Data
 public class DeviceGroup {
 
     @Id

--- a/src/main/java/se/hydroleaf/model/LatestActuatorStatus.java
+++ b/src/main/java/se/hydroleaf/model/LatestActuatorStatus.java
@@ -3,8 +3,11 @@ package se.hydroleaf.model;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.time.Instant;
 
@@ -18,7 +21,10 @@ import java.time.Instant;
                 @Index(name = "ix_las_actuator_device", columnList = "actuator_type, composite_id")
         }
 )
-@Data
+@Getter
+@Setter
+@EqualsAndHashCode(exclude = "device")
+@ToString(exclude = "device")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/se/hydroleaf/model/LatestSensorValue.java
+++ b/src/main/java/se/hydroleaf/model/LatestSensorValue.java
@@ -3,8 +3,11 @@ package se.hydroleaf.model;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.time.Instant;
 
@@ -18,7 +21,10 @@ import java.time.Instant;
                 @Index(name = "ix_lsv_sensor_device", columnList = "sensor_type, composite_id")
         }
 )
-@Data
+@Getter
+@Setter
+@EqualsAndHashCode(exclude = "device")
+@ToString(exclude = "device")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/se/hydroleaf/model/SensorData.java
+++ b/src/main/java/se/hydroleaf/model/SensorData.java
@@ -3,8 +3,11 @@ package se.hydroleaf.model;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(
@@ -17,10 +20,13 @@ import lombok.NoArgsConstructor;
                 @Index(name = "ix_data_record", columnList = "record_id")
         }
 )
+@Getter
+@Setter
+@EqualsAndHashCode(exclude = "record")
+@ToString(exclude = "record")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Data
 public class SensorData {
 
     @Id

--- a/src/main/java/se/hydroleaf/model/SensorHealthItem.java
+++ b/src/main/java/se/hydroleaf/model/SensorHealthItem.java
@@ -3,8 +3,11 @@ package se.hydroleaf.model;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Table(
@@ -17,10 +20,13 @@ import lombok.NoArgsConstructor;
                 @Index(name = "ix_health_record", columnList = "record_id")
         }
 )
+@Getter
+@Setter
+@EqualsAndHashCode(exclude = "record")
+@ToString(exclude = "record")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Data
 public class SensorHealthItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/se/hydroleaf/model/SensorRecord.java
+++ b/src/main/java/se/hydroleaf/model/SensorRecord.java
@@ -3,8 +3,11 @@ package se.hydroleaf.model;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -17,10 +20,13 @@ import java.util.List;
                 @Index(name = "ix_record_device_time", columnList = "device_composite_id, record_time DESC")
         }
 )
+@Getter
+@Setter
+@EqualsAndHashCode(exclude = {"device", "values", "healthItems"})
+@ToString(exclude = {"device", "values", "healthItems"})
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Data
 public class SensorRecord {
 
     @Id


### PR DESCRIPTION
## Summary
- Replace `@Data` with explicit `@Getter` and `@Setter` on all model entities
- Add selective `@EqualsAndHashCode` and `@ToString` annotations while excluding relationship fields to avoid lazy-loading loops

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for se.hydroleaf:demo:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a036060c9483288961e8886f1b1d0e