### PR TITLE
refactor mqtt topic parsing

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
@@ -81,23 +81,34 @@ public class MqttMessageHandler {
         return null;
     }
 
-    private static final Pattern GROW_PATTERN =
-            Pattern.compile("^growSensors/(S\\d+)/(L\\d+)/([^/]+)$");
+    private enum TopicPrefix {
+        GROW("growSensors"),
+        WATER("waterTank");
 
-    private static final Pattern WATER_PATTERN =
-            Pattern.compile("^waterTank/(S\\d+)/(L\\d+)/([^/]+)$");
+        private final Pattern pattern;
 
-    private String deriveCompositeIdFromTopic(String topic) {
-        if (topic == null) return null;
-        Matcher m = GROW_PATTERN.matcher(topic);
-        if (m.find()) {
-            return m.group(1) + "-" + m.group(2) + "-" + m.group(3);
+        TopicPrefix(String prefix) {
+            this.pattern = Pattern.compile("^" + prefix + "/(S\\d+)/(L\\d+)/([^/]+)$");
         }
-        m = WATER_PATTERN.matcher(topic);
-        if (m.find()) {
-            return m.group(1) + "-" + m.group(2) + "-" + m.group(3);
+    }
+
+    private static String deriveCompositeId(Matcher matcher) {
+        return matcher.group(1) + "-" + matcher.group(2) + "-" + matcher.group(3);
+    }
+
+    private static String deriveCompositeIdFromSupportedPrefixes(String topic) {
+        if (topic == null) return null;
+        for (TopicPrefix prefix : TopicPrefix.values()) {
+            Matcher matcher = prefix.pattern.matcher(topic);
+            if (matcher.find()) {
+                return deriveCompositeId(matcher);
+            }
         }
         return null;
+    }
+
+    private String deriveCompositeIdFromTopic(String topic) {
+        return deriveCompositeIdFromSupportedPrefixes(topic);
     }
 
 }


### PR DESCRIPTION
## Summary
- consolidate MQTT topic patterns into `TopicPrefix` enum
- add helper to extract composite ID from supported prefixes
- simplify `deriveCompositeIdFromTopic`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68a03c192c588328a251013af4e565f0