### PR TITLE
refactor: centralize topic publishing

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/TopicPublisher.java
+++ b/src/main/java/se/hydroleaf/mqtt/TopicPublisher.java
@@ -1,0 +1,33 @@
+package se.hydroleaf.mqtt;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Publishes messages to STOMP topics when publishing is enabled.
+ * If disabled, it logs the intended destination and payload instead.
+ */
+@Slf4j
+@Service
+public class TopicPublisher {
+
+    private final boolean publishEnabled;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public TopicPublisher(@Value("${mqtt.publishEnabled:true}") boolean publishEnabled,
+                          SimpMessagingTemplate messagingTemplate) {
+        this.publishEnabled = publishEnabled;
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    public void publish(String destination, Object payload) {
+        if (publishEnabled) {
+            messagingTemplate.convertAndSend(destination, payload);
+        } else {
+            log.info("Should publish to {} with payload: {}", destination, payload);
+        }
+    }
+}
+

--- a/src/test/java/se/hydroleaf/mqtt/MqttMessageHandlerWaterTankTest.java
+++ b/src/test/java/se/hydroleaf/mqtt/MqttMessageHandlerWaterTankTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import se.hydroleaf.service.DeviceProvisionService;
 import se.hydroleaf.service.RecordService;
 
@@ -25,7 +24,7 @@ class MqttMessageHandlerWaterTankTest {
     @Mock
     RecordService recordService;
     @Mock
-    SimpMessagingTemplate messagingTemplate;
+    TopicPublisher topicPublisher;
     @Mock
     DeviceProvisionService deviceProvisionService;
 
@@ -37,7 +36,7 @@ class MqttMessageHandlerWaterTankTest {
     void setup() {
         objectMapper = new ObjectMapper();
         lastSeen = new ConcurrentHashMap<>();
-        handler = new MqttMessageHandler(false, objectMapper, recordService, messagingTemplate, deviceProvisionService, lastSeen);
+        handler = new MqttMessageHandler(objectMapper, recordService, topicPublisher, deviceProvisionService, lastSeen);
     }
 
     @Test

--- a/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
+++ b/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
@@ -6,6 +6,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import se.hydroleaf.mqtt.TopicPublisher;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -81,7 +82,8 @@ class LiveFeedSchedulerTest {
         ObjectMapper mapper = new ObjectMapper()
                 .registerModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-        LiveFeedScheduler scheduler = new LiveFeedScheduler(true, statusService, messagingTemplate, new ConcurrentHashMap<>(), mapper);
+        TopicPublisher topicPublisher = new TopicPublisher(true, messagingTemplate);
+        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, new ConcurrentHashMap<>(), mapper);
         scheduler.sendLiveNow();
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
@@ -107,7 +109,8 @@ class LiveFeedSchedulerTest {
                 .thenThrow(new com.fasterxml.jackson.core.JsonProcessingException("boom") {})
                 .thenReturn("{}");
 
-        LiveFeedScheduler scheduler = new LiveFeedScheduler(true, statusService, messagingTemplate, new ConcurrentHashMap<>(), mapper);
+        TopicPublisher topicPublisher = new TopicPublisher(true, messagingTemplate);
+        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, new ConcurrentHashMap<>(), mapper);
 
         assertDoesNotThrow(scheduler::sendLiveNow);
         scheduler.sendLiveNow();


### PR DESCRIPTION
## Summary
- add TopicPublisher wrapper around SimpMessagingTemplate honoring mqtt.publishEnabled
- use TopicPublisher in MqttMessageHandler and LiveFeedScheduler instead of inline checks
- update tests for new constructor signatures

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a03d7f616483289d04e9e9e27a2ab5