### PR TITLE
Introduce LastSeenRegistry for live feed tracking

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
@@ -7,8 +7,7 @@ import org.springframework.stereotype.Component;
 import se.hydroleaf.service.DeviceProvisionService;
 import se.hydroleaf.service.RecordService;
 
-import java.time.Instant;
-import java.util.concurrent.ConcurrentHashMap;
+import se.hydroleaf.scheduler.LastSeenRegistry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -25,13 +24,13 @@ public class MqttMessageHandler {
     private final TopicPublisher topicPublisher;
     private final DeviceProvisionService deviceProvisionService;
 
-    private final ConcurrentHashMap<String, Instant> lastSeen;
+    private final LastSeenRegistry lastSeen;
 
     public MqttMessageHandler(ObjectMapper objectMapper,
                               RecordService recordService,
                               TopicPublisher topicPublisher,
                               DeviceProvisionService deviceProvisionService,
-                              ConcurrentHashMap<String, Instant> lastSeen) {
+                              LastSeenRegistry lastSeen) {
         this.objectMapper = objectMapper;
         this.recordService = recordService;
         this.topicPublisher = topicPublisher;
@@ -59,7 +58,7 @@ public class MqttMessageHandler {
 
             deviceProvisionService.ensureDevice(compositeId, topic);
             recordService.saveRecord(compositeId, node);
-            lastSeen.put(compositeId, Instant.now());
+            lastSeen.update(compositeId);
         } catch (Exception ex) {
             log.error("MQTT handle error for topic {}: {}", topic, ex.getMessage(), ex);
         }

--- a/src/main/java/se/hydroleaf/scheduler/LastSeenRegistry.java
+++ b/src/main/java/se/hydroleaf/scheduler/LastSeenRegistry.java
@@ -1,0 +1,51 @@
+package se.hydroleaf.scheduler;
+
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+
+/**
+ * Registry keeping track of when devices were last seen.
+ */
+public class LastSeenRegistry {
+
+    private final ConcurrentHashMap<String, Instant> lastSeen = new ConcurrentHashMap<>();
+
+    /**
+     * Updates the registry with the current time for the given composite id.
+     *
+     * @param compositeId device composite id
+     */
+    public void update(String compositeId) {
+        lastSeen.put(compositeId, Instant.now());
+    }
+
+    /**
+     * Iterates over all registry entries.
+     *
+     * @param action action to perform for each entry
+     */
+    public void forEach(BiConsumer<? super String, ? super Instant> action) {
+        lastSeen.forEach(action);
+    }
+
+    /**
+     * Whether the registry contains the given id.
+     *
+     * @param compositeId device composite id
+     * @return true if the id exists in the registry
+     */
+    public boolean contains(String compositeId) {
+        return lastSeen.containsKey(compositeId);
+    }
+
+    /**
+     * Whether the registry is empty.
+     *
+     * @return true if no entries exist
+     */
+    public boolean isEmpty() {
+        return lastSeen.isEmpty();
+    }
+}
+

--- a/src/main/java/se/hydroleaf/scheduler/LiveFeedConfig.java
+++ b/src/main/java/se/hydroleaf/scheduler/LiveFeedConfig.java
@@ -3,14 +3,12 @@ package se.hydroleaf.scheduler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.time.Instant;
-import java.util.concurrent.ConcurrentHashMap;
-
 @Configuration
 public class LiveFeedConfig {
 
     @Bean
-    public ConcurrentHashMap<String, Instant> lastSeen() {
-        return new ConcurrentHashMap<>();
+    public LastSeenRegistry lastSeenRegistry() {
+        return new LastSeenRegistry();
     }
 }
+

--- a/src/main/java/se/hydroleaf/scheduler/LiveFeedScheduler.java
+++ b/src/main/java/se/hydroleaf/scheduler/LiveFeedScheduler.java
@@ -11,7 +11,6 @@ import se.hydroleaf.service.StatusService;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Periodic tasks related to live device feed.
@@ -22,12 +21,12 @@ public class LiveFeedScheduler {
 
     private final StatusService statusService;
     private final TopicPublisher topicPublisher;
-    private final ConcurrentHashMap<String, Instant> lastSeen;
+    private final LastSeenRegistry lastSeen;
     private final ObjectMapper objectMapper;
     private Instant lastInvocation;
     public LiveFeedScheduler(StatusService statusService,
                              TopicPublisher topicPublisher,
-                             ConcurrentHashMap<String, Instant> lastSeen,
+                             LastSeenRegistry lastSeen,
                              ObjectMapper objectMapper) {
         this.statusService = statusService;
         this.topicPublisher = topicPublisher;

--- a/src/test/java/se/hydroleaf/mqtt/MqttMessageHandlerWaterTankTest.java
+++ b/src/test/java/se/hydroleaf/mqtt/MqttMessageHandlerWaterTankTest.java
@@ -9,8 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import se.hydroleaf.service.DeviceProvisionService;
 import se.hydroleaf.service.RecordService;
 
-import java.time.Instant;
-import java.util.concurrent.ConcurrentHashMap;
+import se.hydroleaf.scheduler.LastSeenRegistry;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,13 +28,13 @@ class MqttMessageHandlerWaterTankTest {
     DeviceProvisionService deviceProvisionService;
 
     ObjectMapper objectMapper;
-    ConcurrentHashMap<String, Instant> lastSeen;
+    LastSeenRegistry lastSeen;
     MqttMessageHandler handler;
 
     @BeforeEach
     void setup() {
         objectMapper = new ObjectMapper();
-        lastSeen = new ConcurrentHashMap<>();
+        lastSeen = new LastSeenRegistry();
         handler = new MqttMessageHandler(objectMapper, recordService, topicPublisher, deviceProvisionService, lastSeen);
     }
 
@@ -48,7 +47,7 @@ class MqttMessageHandlerWaterTankTest {
 
         verify(deviceProvisionService).ensureDevice(eq("S01-L01-probe1"), eq(topic));
         verify(recordService).saveRecord(eq("S01-L01-probe1"), any());
-        assertTrue(lastSeen.containsKey("S01-L01-probe1"));
+        assertTrue(lastSeen.contains("S01-L01-probe1"));
     }
 
     @Test

--- a/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
+++ b/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
@@ -22,7 +22,6 @@ import se.hydroleaf.service.StatusService;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -83,7 +82,7 @@ class LiveFeedSchedulerTest {
                 .registerModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         TopicPublisher topicPublisher = new TopicPublisher(true, messagingTemplate);
-        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, new ConcurrentHashMap<>(), mapper);
+        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, new LastSeenRegistry(), mapper);
         scheduler.sendLiveNow();
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
@@ -110,7 +109,7 @@ class LiveFeedSchedulerTest {
                 .thenReturn("{}");
 
         TopicPublisher topicPublisher = new TopicPublisher(true, messagingTemplate);
-        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, new ConcurrentHashMap<>(), mapper);
+        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, new LastSeenRegistry(), mapper);
 
         assertDoesNotThrow(scheduler::sendLiveNow);
         scheduler.sendLiveNow();


### PR DESCRIPTION
## Summary
- add `LastSeenRegistry` to encapsulate last-seen timestamps
- expose `LastSeenRegistry` as Spring bean and wire into MQTT handling and scheduler
- update tests to accommodate new registry

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a042692b8c83289ce545817f920e3d