### PR TITLE
Refactor repositories to use generic aggregate query

### DIFF
--- a/src/main/java/se/hydroleaf/repository/ActuatorStatusRepository.java
+++ b/src/main/java/se/hydroleaf/repository/ActuatorStatusRepository.java
@@ -1,46 +1,17 @@
 package se.hydroleaf.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import se.hydroleaf.model.ActuatorStatus;
 
 import java.util.Optional;
 
 @Repository
-public interface ActuatorStatusRepository extends JpaRepository<ActuatorStatus, Long> {
+public interface ActuatorStatusRepository extends JpaRepository<ActuatorStatus, Long>, ActuatorStatusRepositoryCustom {
 
     /**
      * Latest actuator state for a device and actuator type.
      */
     Optional<ActuatorStatus> findTopByDeviceCompositeIdAndActuatorTypeOrderByTimestampDesc(String compositeId, String actuatorType);
 
-    /**
-     * Latest actuator state across devices of a system/layer as ON ratio in [0..1].
-     * Postgres DISTINCT ON or window functions to pick the latest row per device.
-     */
-    @Query(value = """
-            WITH latest AS (
-              SELECT
-                a.composite_id,
-                a.state,
-                a.status_time,
-                ROW_NUMBER() OVER (
-                  PARTITION BY a.composite_id
-                  ORDER BY a.status_time DESC
-                ) AS rn
-              FROM actuator_status a
-              JOIN device d ON d.composite_id = a.composite_id
-              WHERE d.system = :system AND d.layer = :layer AND a.actuator_type = :actuatorType
-            )
-            SELECT
-              COALESCE(AVG(CASE WHEN state THEN 1 ELSE 0 END), 0) AS average,
-              CAST(COUNT(*) AS INTEGER)                             AS count
-            FROM latest
-            WHERE rn = 1
-            """, nativeQuery = true)
-    AverageResult getLatestActuatorAverage(@Param("system") String system,
-                                           @Param("layer") String layer,
-                                           @Param("actuatorType") String actuatorType);
 }

--- a/src/main/java/se/hydroleaf/repository/ActuatorStatusRepositoryCustom.java
+++ b/src/main/java/se/hydroleaf/repository/ActuatorStatusRepositoryCustom.java
@@ -1,0 +1,6 @@
+package se.hydroleaf.repository;
+
+public interface ActuatorStatusRepositoryCustom {
+    AverageCount getLatestActuatorAverage(String system, String layer, String actuatorType);
+}
+

--- a/src/main/java/se/hydroleaf/repository/ActuatorStatusRepositoryImpl.java
+++ b/src/main/java/se/hydroleaf/repository/ActuatorStatusRepositoryImpl.java
@@ -1,0 +1,19 @@
+package se.hydroleaf.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ActuatorStatusRepositoryImpl implements ActuatorStatusRepositoryCustom {
+
+    private final AggregateRepository aggregateRepository;
+
+    public ActuatorStatusRepositoryImpl(AggregateRepository aggregateRepository) {
+        this.aggregateRepository = aggregateRepository;
+    }
+
+    @Override
+    public AverageCount getLatestActuatorAverage(String system, String layer, String actuatorType) {
+        return aggregateRepository.getLatestAverage(system, layer, actuatorType, "actuator_status");
+    }
+}
+

--- a/src/main/java/se/hydroleaf/repository/AggregateRepository.java
+++ b/src/main/java/se/hydroleaf/repository/AggregateRepository.java
@@ -1,0 +1,74 @@
+package se.hydroleaf.repository;
+
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+
+@Repository
+public class AggregateRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public AggregateRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    private record Config(String from, String deviceCol, String typeCol, String valueExpr, String timeCol) {}
+
+    private static final Map<String, Config> CONFIGS = Map.of(
+            "actuator_status", new Config(
+                    "actuator_status a",
+                    "a.composite_id",
+                    "a.actuator_type",
+                    "CASE WHEN a.state THEN 1.0 ELSE 0.0 END",
+                    "a.status_time"
+            ),
+            "sensor_data", new Config(
+                    "sensor_record sr JOIN sensor_data sd ON sd.record_id = sr.id",
+                    "sr.device_composite_id",
+                    "sd.sensor_type",
+                    "sd.sensor_value",
+                    "sr.record_time"
+            )
+    );
+
+    public AverageCount getLatestAverage(String system, String layer, String type, String tableName) {
+        Config cfg = CONFIGS.get(tableName);
+        if (cfg == null) {
+            throw new IllegalArgumentException("Unknown table: " + tableName);
+        }
+
+        String sql = String.format("""
+            WITH latest AS (
+              SELECT
+                %1$s AS composite_id,
+                %2$s AS value,
+                %5$s AS ts,
+                ROW_NUMBER() OVER (
+                  PARTITION BY %1$s
+                  ORDER BY %5$s DESC
+                ) AS rn
+              FROM %4$s
+              JOIN device d ON d.composite_id = %1$s
+              WHERE d.system = :system AND d.layer = :layer AND %3$s = :type
+            )
+            SELECT
+              COALESCE(AVG(value), 0) AS average,
+              CAST(COUNT(value) AS INTEGER) AS count
+            FROM latest
+            WHERE rn = 1
+            """, cfg.deviceCol, cfg.valueExpr, cfg.typeCol, cfg.from, cfg.timeCol);
+
+        Map<String, Object> params = Map.of(
+                "system", system,
+                "layer", layer,
+                "type", type
+        );
+
+        return jdbcTemplate.queryForObject(sql, params, (rs, rowNum) ->
+                new AverageCount(rs.getDouble("average"), rs.getLong("count"))
+        );
+    }
+}
+

--- a/src/main/java/se/hydroleaf/repository/AverageCount.java
+++ b/src/main/java/se/hydroleaf/repository/AverageCount.java
@@ -1,0 +1,4 @@
+package se.hydroleaf.repository;
+
+public record AverageCount(Double average, Long count) {}
+

--- a/src/main/java/se/hydroleaf/repository/AverageResult.java
+++ b/src/main/java/se/hydroleaf/repository/AverageResult.java
@@ -1,6 +1,0 @@
-package se.hydroleaf.repository;
-
-public interface AverageResult {
-    Double getAverage();
-    Long getCount();
-}

--- a/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
@@ -1,47 +1,17 @@
 package se.hydroleaf.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import se.hydroleaf.model.SensorData;
 
 import java.util.Optional;
 
 @Repository
-public interface SensorDataRepository extends JpaRepository<SensorData, Long> {
+public interface SensorDataRepository extends JpaRepository<SensorData, Long>, SensorDataRepositoryCustom {
 
     /**
      * Latest sensor reading for a device and sensor type.
      */
     Optional<SensorData> findTopByRecord_DeviceCompositeIdAndSensorTypeOrderByRecord_TimestampDesc(String compositeId,
                                                                                                    String sensorType);
-
-    @Query(value = """
-            WITH last_rec AS (
-              SELECT
-                sr.id,
-                sr.device_composite_id,
-                ROW_NUMBER() OVER (
-                  PARTITION BY sr.device_composite_id
-                  ORDER BY sr.record_time DESC
-                ) AS rn
-              FROM sensor_record sr
-              JOIN device d ON d.composite_id = sr.device_composite_id
-              WHERE d.system = :system AND d.layer = :layer
-            )
-            SELECT
-              COALESCE(AVG(sd.sensor_value), 0)                     AS average,
-              CAST(COUNT(sd.sensor_value) AS INTEGER)               AS count
-            FROM last_rec lr
-            JOIN sensor_data sd ON sd.record_id = lr.id
-            WHERE lr.rn = 1                                         -- latest per device
-              AND sd.sensor_type = :sensorType
-            """, nativeQuery = true)
-    AverageResult getLatestAverage(
-            @Param("system") String system,
-            @Param("layer") String layer,
-            @Param("sensorType") String sensorType
-    );
-
 }

--- a/src/main/java/se/hydroleaf/repository/SensorDataRepositoryCustom.java
+++ b/src/main/java/se/hydroleaf/repository/SensorDataRepositoryCustom.java
@@ -1,0 +1,6 @@
+package se.hydroleaf.repository;
+
+public interface SensorDataRepositoryCustom {
+    AverageCount getLatestAverage(String system, String layer, String sensorType);
+}
+

--- a/src/main/java/se/hydroleaf/repository/SensorDataRepositoryImpl.java
+++ b/src/main/java/se/hydroleaf/repository/SensorDataRepositoryImpl.java
@@ -1,0 +1,19 @@
+package se.hydroleaf.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SensorDataRepositoryImpl implements SensorDataRepositoryCustom {
+
+    private final AggregateRepository aggregateRepository;
+
+    public SensorDataRepositoryImpl(AggregateRepository aggregateRepository) {
+        this.aggregateRepository = aggregateRepository;
+    }
+
+    @Override
+    public AverageCount getLatestAverage(String system, String layer, String sensorType) {
+        return aggregateRepository.getLatestAverage(system, layer, sensorType, "sensor_data");
+    }
+}
+


### PR DESCRIPTION
## Summary
- centralize latest average SQL in new AggregateRepository
- delegate sensor and actuator repositories to the aggregate repository
- introduce shared AverageCount record

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a05e752e308328981c3b5f35aa9011