### PR TITLE
Add explicit getters to AverageCount record

### DIFF
--- a/src/main/java/se/hydroleaf/repository/AverageCount.java
+++ b/src/main/java/se/hydroleaf/repository/AverageCount.java
@@ -1,0 +1,6 @@
+package se.hydroleaf.repository;
+
+public record AverageCount(Double average, Long count) {
+    public Double getAverage() { return average; }
+    public Long getCount() { return count; }
+}


### PR DESCRIPTION
## Summary
- add new `AverageCount` record with bean-style `getAverage` and `getCount` accessors for compatibility

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for se.hydroleaf:demo:0.0.1-SNAPSHOT: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a060a1417c83288d3ad501081037f5