### PR TITLE
Introduce SensorAggregationRow DTO and adjust aggregation code

### DIFF
--- a/src/main/java/se/hydroleaf/repository/SensorAggregationRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorAggregationRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import se.hydroleaf.model.SensorRecord;
+import se.hydroleaf.repository.dto.SensorAggregationRow;
 
 import java.time.Instant;
 import java.util.List;
@@ -13,22 +14,12 @@ import java.util.List;
 @Repository
 public interface SensorAggregationRepository extends JpaRepository<SensorRecord, Long> {
 
-    interface Row {
-        String getSensorType();
-
-        String getUnit();
-
-        Instant getBucketTime();
-
-        Double getAvgValue();
-    }
-
     @Query(value = """
             SELECT
+              sd.sensor_type AS sensor_type,
+              sd.unit        AS unit,
               to_timestamp(floor(extract(epoch from sr.record_time) / :bucketSec) * :bucketSec) AS bucket_time,
-            sd.sensor_type AS sensor_type,
-            sd.unit        AS unit,
-            AVG(sd.sensor_value) AS avg_value
+              AVG(sd.sensor_value) AS avg_value
             FROM sensor_record sr
             JOIN sensor_data sd ON sd.record_id = sr.id
             WHERE sr.device_composite_id = :compositeId
@@ -38,7 +29,7 @@ public interface SensorAggregationRepository extends JpaRepository<SensorRecord,
             GROUP BY bucket_time, sd.sensor_type, sd.unit
             ORDER BY bucket_time
             """, nativeQuery = true)
-    List<Row> aggregate(
+    List<SensorAggregationRow> aggregate(
             @Param("compositeId") String compositeId,
             @Param("fromTs") Instant from,
             @Param("toTs") Instant to,

--- a/src/main/java/se/hydroleaf/repository/dto/SensorAggregationRow.java
+++ b/src/main/java/se/hydroleaf/repository/dto/SensorAggregationRow.java
@@ -1,0 +1,10 @@
+package se.hydroleaf.repository.dto;
+
+import java.time.Instant;
+
+public record SensorAggregationRow(
+        String sensorType,
+        String unit,
+        Instant bucketTime,
+        Double avgValue
+) {}

--- a/src/main/java/se/hydroleaf/service/SensorAggregationAdapter.java
+++ b/src/main/java/se/hydroleaf/service/SensorAggregationAdapter.java
@@ -3,6 +3,7 @@ package se.hydroleaf.service;
 
 import org.springframework.stereotype.Component;
 import se.hydroleaf.repository.SensorAggregationRepository;
+import se.hydroleaf.repository.dto.SensorAggregationRow;
 import se.hydroleaf.util.InstantUtil;
 
 import java.time.Instant;
@@ -28,12 +29,12 @@ public class SensorAggregationAdapter implements RecordService.SensorAggregation
         var rows = repo.aggregate(compositeId, from, to, sec);
         List<RecordService.SensorAggregateResult> out = new ArrayList<>(rows.size());
 
-        for (SensorAggregationRepository.Row r : rows) {
+        for (SensorAggregationRow r : rows) {
             out.add(new RowImpl(
-                    r.getSensorType(),
-                    r.getUnit(),
-                    r.getBucketTime(),
-                    r.getAvgValue()
+                    r.sensorType(),
+                    r.unit(),
+                    r.bucketTime(),
+                    r.avgValue()
             ));
         }
         return out;


### PR DESCRIPTION
## Summary
- add SensorAggregationRow record for sensor type, unit, bucket time and average value
- return SensorAggregationRow from SensorAggregationRepository.aggregate
- update SensorAggregationAdapter to consume SensorAggregationRow

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0671e29d08328a057b3a1d700b98f