### PR TITLE
refactor: remove @Repository from interfaces

### DIFF
--- a/src/main/java/se/hydroleaf/repository/ActuatorStatusRepository.java
+++ b/src/main/java/se/hydroleaf/repository/ActuatorStatusRepository.java
@@ -1,12 +1,10 @@
 package se.hydroleaf.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 import se.hydroleaf.model.ActuatorStatus;
 
 import java.util.Optional;
 
-@Repository
 public interface ActuatorStatusRepository extends JpaRepository<ActuatorStatus, Long>, ActuatorStatusRepositoryCustom {
 
     /**

--- a/src/main/java/se/hydroleaf/repository/SensorAggregationRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorAggregationRepository.java
@@ -4,14 +4,12 @@ package se.hydroleaf.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 import se.hydroleaf.model.SensorRecord;
 import se.hydroleaf.repository.dto.SensorAggregationRow;
 
 import java.time.Instant;
 import java.util.List;
 
-@Repository
 public interface SensorAggregationRepository extends JpaRepository<SensorRecord, Long> {
 
     @Query(value = """

--- a/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
@@ -1,12 +1,10 @@
 package se.hydroleaf.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 import se.hydroleaf.model.SensorData;
 
 import java.util.Optional;
 
-@Repository
 public interface SensorDataRepository extends JpaRepository<SensorData, Long>, SensorDataRepositoryCustom {
 
     /**


### PR DESCRIPTION
## Summary
- remove explicit `@Repository` annotations from repository interfaces and let Spring Data detect them automatically

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0685c66e8832883cbe9267d4e382e