### PR TITLE
Add migration to enable TimescaleDB extension

### DIFF
--- a/src/main/resources/db/migration/V1__enable_timescaledb.sql
+++ b/src/main/resources/db/migration/V1__enable_timescaledb.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS timescaledb;


### PR DESCRIPTION
## Summary
- add Flyway V1 migration that installs the TimescaleDB extension if not present, ensuring availability before other migrations use time_bucket

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch Maven binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68a0802a12a083289257b2e0e82aad48