### PR TITLE
Use TimescaleDB image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
 version: '3.8'
 services:
   db:
-    image: postgres:15-alpine
+    image: timescale/timescaledb:2.15.1-pg15
     environment:
       POSTGRES_DB: nft
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      TS_TELEMETRY: "off"
     ports:
       - "5432:5432"
   mqtt:


### PR DESCRIPTION
## Summary
- switch database service to TimescaleDB 2.15.1 pg15
- disable TimescaleDB telemetry

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*
- `docker-compose config` *(fails: command not found: docker-compose)*

------
https://chatgpt.com/codex/tasks/task_e_68a080e103dc8328a051ba9f0271e43a