### PR TITLE
Add TimescaleDB fallback using date_trunc

### DIFF
--- a/src/main/java/se/hydroleaf/repository/SensorAggregationRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorAggregationRepository.java
@@ -28,7 +28,31 @@ public interface SensorAggregationRepository extends JpaRepository<SensorRecord,
             GROUP BY bucket_time, sd.sensor_type, sd.unit
             ORDER BY bucket_time
             """, nativeQuery = true)
-    List<SensorAggregationRow> aggregate(
+    List<SensorAggregationRow> aggregateTimescale(
+            @Param("compositeId") String compositeId,
+            @Param("fromTs") Instant from,
+            @Param("toTs") Instant to,
+            @Param("bucketSec") long bucketSeconds,
+            @Param("sensorType") String sensorType
+    );
+
+    @Query(value = """
+            SELECT
+              sd.sensor_type AS sensor_type,
+              sd.unit        AS unit,
+              date_trunc('second', to_timestamp(floor(EXTRACT(EPOCH FROM sr.record_time) / :bucketSec) * :bucketSec)) AS bucket_time,
+              AVG(sd.sensor_value) AS avg_value
+            FROM sensor_record sr
+            JOIN sensor_data sd ON sd.record_id = sr.id
+            WHERE sr.device_composite_id = :compositeId
+              AND sr.record_time >= :fromTs
+              AND sr.record_time <  :toTs
+              AND sd.sensor_value IS NOT NULL
+              AND (:sensorType IS NULL OR sd.sensor_type = :sensorType)
+            GROUP BY bucket_time, sd.sensor_type, sd.unit
+            ORDER BY bucket_time
+            """, nativeQuery = true)
+    List<SensorAggregationRow> aggregateDateTrunc(
             @Param("compositeId") String compositeId,
             @Param("fromTs") Instant from,
             @Param("toTs") Instant to,

--- a/src/main/java/se/hydroleaf/repository/TimescaleDbSupport.java
+++ b/src/main/java/se/hydroleaf/repository/TimescaleDbSupport.java
@@ -1,0 +1,46 @@
+package se.hydroleaf.repository;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Detects whether the TimescaleDB extension is available. Detection can be
+ * forced by setting the configuration property {@code app.timescaledb.enabled}.
+ * If the property is not provided, a query against {@code pg_extension} is
+ * executed on startup.
+ */
+@Component
+public class TimescaleDbSupport implements InitializingBean {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final Boolean configured;
+    private boolean available;
+
+    public TimescaleDbSupport(JdbcTemplate jdbcTemplate,
+                              @Value("${app.timescaledb.enabled:#{null}}") Boolean configured) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.configured = configured;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        if (configured != null) {
+            available = configured;
+            return;
+        }
+        try {
+            Integer res = jdbcTemplate.queryForObject(
+                    "SELECT 1 FROM pg_extension WHERE extname = 'timescaledb'",
+                    Integer.class);
+            available = res != null;
+        } catch (Exception ex) {
+            available = false;
+        }
+    }
+
+    public boolean isAvailable() {
+        return available;
+    }
+}

--- a/src/main/resources/db/migration/V4__sensor_aggregation_indexes.sql
+++ b/src/main/resources/db/migration/V4__sensor_aggregation_indexes.sql
@@ -4,5 +4,11 @@ CREATE INDEX IF NOT EXISTS ix_sensor_data_type_record_notnull
     WHERE sensor_value IS NOT NULL;
 
 -- Expression index for common 1 minute bucket to speed up aggregation
-CREATE INDEX IF NOT EXISTS ix_record_device_time_bucket_1m
-    ON sensor_record (device_composite_id, time_bucket('1 minute', record_time));
+-- Only create when TimescaleDB is available
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+        CREATE INDEX IF NOT EXISTS ix_record_device_time_bucket_1m
+            ON sensor_record (device_composite_id, time_bucket('1 minute', record_time));
+    END IF;
+END$$;


### PR DESCRIPTION
## Summary
- support aggregation without TimescaleDB using `date_trunc`
- detect TimescaleDB extension at startup via property or query
- skip `time_bucket` index creation if TimescaleDB is missing

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68a0843499a883288f496daa3207efc4