### PR TITLE
Ensure TimescaleDB extension persists in initial schema

### DIFF
--- a/src/main/resources/db/migration/initial_schema.sql
+++ b/src/main/resources/db/migration/initial_schema.sql
@@ -19,6 +19,9 @@ SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
 
+-- Ensure TimescaleDB is available; keep this when regenerating dumps
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
 --
 -- TOC entry 4 (class 2615 OID 2200)
 -- Name: public; Type: SCHEMA; Schema: -; Owner: pg_database_owner

--- a/src/test/java/se/hydroleaf/db/InitialSchemaTest.java
+++ b/src/test/java/se/hydroleaf/db/InitialSchemaTest.java
@@ -1,0 +1,17 @@
+package se.hydroleaf.db;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class InitialSchemaTest {
+    @Test
+    void initialSchemaContainsTimescaleExtension() throws IOException {
+        String schema = Files.readString(Path.of("src/main/resources/db/migration/initial_schema.sql"));
+        assertTrue(schema.contains("CREATE EXTENSION IF NOT EXISTS timescaledb;"),
+                "initial_schema.sql must include TimescaleDB extension");
+    }
+}


### PR DESCRIPTION
## Summary
- Include `CREATE EXTENSION IF NOT EXISTS timescaledb;` at the top of `initial_schema.sql` to enable TimescaleDB on new databases.
- Add a unit test checking that the schema dump retains the TimescaleDB extension statement.

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a086e1f9b883288ad608cd8517c54c