### PR TITLE
Add migration for sensor data uniqueness

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,8 +14,6 @@ spring:
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
   jpa:
-    hibernate:
-      ddl-auto: update
     show-sql: false
     open-in-view: false
   cache:

--- a/src/main/resources/db/migration/V5__ensure_sensor_data_unique_constraint.sql
+++ b/src/main/resources/db/migration/V5__ensure_sensor_data_unique_constraint.sql
@@ -1,0 +1,10 @@
+-- Ensure unique (record_id, sensor_type) pairs in sensor_data
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'ux_data_record_type'
+    ) THEN
+        ALTER TABLE sensor_data
+            ADD CONSTRAINT ux_data_record_type UNIQUE (record_id, sensor_type);
+    END IF;
+END$$;


### PR DESCRIPTION
## Summary
- rely on Flyway for schema changes by removing `ddl-auto` from production config
- add migration to ensure `(record_id, sensor_type)` pairs are unique

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a08d92bb6083288057819be2bcb419