### PR TITLE
Support hyphenated device IDs in DeviceProvisionService

### DIFF
--- a/src/main/java/se/hydroleaf/model/Device.java
+++ b/src/main/java/se/hydroleaf/model/Device.java
@@ -43,7 +43,7 @@ public class Device {
     private String layer;                       // e.g. L02
 
     @Column(name = "device_id", length = 64, nullable = false)
-    private String deviceId;                    // e.g. esp32-01   <-- (NEW)
+    private String deviceId;                    // e.g. esp32-01 (may contain hyphens)
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "group_id", nullable = false)

--- a/src/main/java/se/hydroleaf/service/DeviceProvisionService.java
+++ b/src/main/java/se/hydroleaf/service/DeviceProvisionService.java
@@ -29,7 +29,9 @@ public class DeviceProvisionService {
             Device d = new Device();
             d.setCompositeId(compositeId);
 
-            String[] parts = compositeId.split("-");
+            // Split only on the first two hyphens so that device IDs may themselves contain
+            // hyphens (e.g. "S01-L02-esp32-01" -> deviceId "esp32-01")
+            String[] parts = compositeId.split("-", 3);
             if (parts.length >= 3) {
                 d.setSystem(parts[0]);
                 d.setLayer(parts[1]);

--- a/src/test/java/se/hydroleaf/service/DeviceProvisionServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/DeviceProvisionServiceTest.java
@@ -1,0 +1,51 @@
+package se.hydroleaf.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.hydroleaf.model.Device;
+import se.hydroleaf.model.DeviceGroup;
+import se.hydroleaf.repository.DeviceGroupRepository;
+import se.hydroleaf.repository.DeviceRepository;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceProvisionServiceTest {
+
+    @Mock
+    private DeviceRepository deviceRepo;
+
+    @Mock
+    private DeviceGroupRepository groupRepo;
+
+    @InjectMocks
+    private DeviceProvisionService service;
+
+    @Test
+    void ensureDevicePreservesHyphenatedDeviceId() {
+        String compositeId = "S01-L02-esp32-01";
+
+        DeviceGroup group = new DeviceGroup();
+        group.setMqttTopic("test");
+
+        when(groupRepo.findByMqttTopic(anyString())).thenReturn(Optional.of(group));
+        when(deviceRepo.findById(compositeId)).thenReturn(Optional.empty());
+        when(deviceRepo.save(any(Device.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Device device = service.ensureDevice(compositeId, null);
+
+        assertEquals("S01", device.getSystem());
+        assertEquals("L02", device.getLayer());
+        assertEquals("esp32-01", device.getDeviceId());
+        assertEquals(compositeId, device.getCompositeId());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Preserve full device IDs by splitting composite IDs on only the first two hyphens.
- Document that device IDs may contain hyphens.
- Add unit test covering hyphenated device ID handling.

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3: Network is unreachable)*
- `mvn -q -o test` *(fails: Cannot access central in offline mode and the artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 has not been downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a2e9c8208328a6de4dbe49e81713