### PR TITLE
Support flexible Instant parsing with fractional seconds

### DIFF
--- a/src/main/java/se/hydroleaf/util/InstantUtil.java
+++ b/src/main/java/se/hydroleaf/util/InstantUtil.java
@@ -10,7 +10,7 @@ public final class InstantUtil {
     private InstantUtil() {}
 
     private static final DateTimeFormatter FLEXIBLE_FORMATTER = new DateTimeFormatterBuilder()
-            .appendPattern("yyyy-MM-dd'T'H:mm:ss")
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss[.SSS]")
             .appendOffsetId()
             .toFormatter();
 
@@ -18,7 +18,11 @@ public final class InstantUtil {
         try {
             return Instant.parse(value);
         } catch (DateTimeParseException e) {
-            return OffsetDateTime.parse(value, FLEXIBLE_FORMATTER).toInstant();
+            try {
+                return OffsetDateTime.parse(value, FLEXIBLE_FORMATTER).toInstant();
+            } catch (DateTimeParseException ex) {
+                throw new IllegalArgumentException("Invalid time format: " + value, ex);
+            }
         }
     }
 

--- a/src/test/java/se/hydroleaf/util/InstantUtilTest.java
+++ b/src/test/java/se/hydroleaf/util/InstantUtilTest.java
@@ -1,0 +1,30 @@
+package se.hydroleaf.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InstantUtilTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "2024-01-02T03:04:05Z",
+            "2024-01-02T03:04:05.123Z",
+            "2024-01-02T03:04:05+02:00",
+            "2024-01-02T03:04:05.123-05:00"
+    })
+    void parsesFlexibleFormats(String input) {
+        Instant expected = OffsetDateTime.parse(input).toInstant();
+        assertEquals(expected, InstantUtil.parse(input));
+    }
+
+    @Test
+    void invalidInputThrows() {
+        assertThrows(IllegalArgumentException.class, () -> InstantUtil.parse("invalid"));
+    }
+}


### PR DESCRIPTION
## Summary
- Expand `InstantUtil` formatter to accept hours with leading zeros and optional milliseconds
- Report invalid date strings with a clear `IllegalArgumentException`
- Cover ISO-8601 parsing with offsets and fractional seconds in unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a4711660832896fc0e8f9efedc90