### PR TITLE
Guard migration object creation with IF NOT EXISTS

### DIFF
--- a/src/main/resources/db/migration/V2__add_latest_sensor_value.sql
+++ b/src/main/resources/db/migration/V2__add_latest_sensor_value.sql
@@ -1,4 +1,4 @@
-CREATE TABLE latest_sensor_value (
+CREATE TABLE IF NOT EXISTS latest_sensor_value (
     id BIGSERIAL PRIMARY KEY,
     composite_id VARCHAR(128) NOT NULL,
     sensor_type VARCHAR(64) NOT NULL,
@@ -9,4 +9,4 @@ CREATE TABLE latest_sensor_value (
     CONSTRAINT ux_lsv_device_sensor UNIQUE (composite_id, sensor_type)
 );
 
-CREATE INDEX ix_lsv_sensor_device ON latest_sensor_value (sensor_type, composite_id);
+CREATE INDEX IF NOT EXISTS ix_lsv_sensor_device ON latest_sensor_value (sensor_type, composite_id);

--- a/src/main/resources/db/migration/V3__add_latest_actuator_status.sql
+++ b/src/main/resources/db/migration/V3__add_latest_actuator_status.sql
@@ -1,4 +1,4 @@
-CREATE TABLE latest_actuator_status (
+CREATE TABLE IF NOT EXISTS latest_actuator_status (
     id BIGSERIAL PRIMARY KEY,
     composite_id VARCHAR(128) NOT NULL,
     actuator_type VARCHAR(64) NOT NULL,
@@ -8,4 +8,4 @@ CREATE TABLE latest_actuator_status (
     CONSTRAINT ux_las_device_actuator UNIQUE (composite_id, actuator_type)
 );
 
-CREATE INDEX ix_las_actuator_device ON latest_actuator_status (actuator_type, composite_id);
+CREATE INDEX IF NOT EXISTS ix_las_actuator_device ON latest_actuator_status (actuator_type, composite_id);


### PR DESCRIPTION
## Summary
- prevent migration failures by adding `IF NOT EXISTS` to latest sensor value table and index
- apply same safeguard for latest actuator status table and index

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a4e48c988328a74d4bbce6910f3d