### PR TITLE
Use BigInt count for aggregate queries

### DIFF
--- a/src/main/java/se/hydroleaf/repository/AggregateRepository.java
+++ b/src/main/java/se/hydroleaf/repository/AggregateRepository.java
@@ -55,7 +55,7 @@ public class AggregateRepository {
             )
             SELECT
               COALESCE(AVG(val), 0) AS average,
-              CAST(COUNT(val) AS INTEGER) AS count
+              CAST(COUNT(val) AS BIGINT) AS count
             FROM latest
             WHERE rn = 1
             """, cfg.deviceCol, cfg.valueExpr, cfg.typeCol, cfg.from, cfg.timeCol);

--- a/src/test/java/se/hydroleaf/repository/AggregateRepositoryTest.java
+++ b/src/test/java/se/hydroleaf/repository/AggregateRepositoryTest.java
@@ -1,0 +1,53 @@
+package se.hydroleaf.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AggregateRepositoryTest {
+
+    @Mock
+    NamedParameterJdbcTemplate jdbcTemplate;
+
+    AggregateRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new AggregateRepository(jdbcTemplate);
+    }
+
+    @Test
+    void handlesLargeCounts() throws SQLException {
+        long largeCount = (long) Integer.MAX_VALUE + 5L;
+
+        when(jdbcTemplate.queryForObject(anyString(), anyMap(), isA(RowMapper.class)))
+                .thenAnswer(invocation -> {
+                    @SuppressWarnings("unchecked")
+                    RowMapper<AverageCount> mapper = (RowMapper<AverageCount>) invocation.getArgument(2);
+                    ResultSet rs = mock(ResultSet.class);
+                    when(rs.getDouble("average")).thenReturn(0.0);
+                    when(rs.getLong("count")).thenReturn(largeCount);
+                    return mapper.mapRow(rs, 1);
+                });
+
+        AverageCount result = repository.getLatestAverage("sys", "layer", "type", "actuator_status");
+
+        assertEquals(largeCount, result.getCount());
+    }
+}
+


### PR DESCRIPTION
## Summary
- Cast aggregate counts to `BIGINT` in `AggregateRepository`.
- Ensure `AverageCount` retrieval uses `Long` and add test for large counts.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a5724b508328a7d144422a97fa52