### PR TITLE
Add safety checks to actuator status migration

### DIFF
--- a/src/main/resources/db/migration/V3__add_latest_actuator_status.sql
+++ b/src/main/resources/db/migration/V3__add_latest_actuator_status.sql
@@ -1,4 +1,4 @@
-CREATE TABLE latest_actuator_status (
+CREATE TABLE IF NOT EXISTS latest_actuator_status (
     id BIGSERIAL PRIMARY KEY,
     composite_id VARCHAR(128) NOT NULL,
     actuator_type VARCHAR(64) NOT NULL,
@@ -8,4 +8,4 @@ CREATE TABLE latest_actuator_status (
     CONSTRAINT ux_las_device_actuator UNIQUE (composite_id, actuator_type)
 );
 
-CREATE INDEX ix_las_actuator_device ON latest_actuator_status (actuator_type, composite_id);
+CREATE INDEX IF NOT EXISTS ix_las_actuator_device ON latest_actuator_status (actuator_type, composite_id);


### PR DESCRIPTION
## Summary
- add IF NOT EXISTS checks for `latest_actuator_status` table and index

## Testing
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a50d385c832884593caa7ad88868