### PR TITLE
Publish valid MQTT messages only

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
@@ -39,7 +39,6 @@ public class MqttMessageHandler {
     }
 
     public void handle(String topic, String payload) {
-        topicPublisher.publish("/topic/" + topic, payload);
         try {
             JsonNode node = objectMapper.readTree(payload);
 
@@ -59,6 +58,8 @@ public class MqttMessageHandler {
             deviceProvisionService.ensureDevice(compositeId, topic);
             recordService.saveRecord(compositeId, node);
             lastSeen.update(compositeId);
+
+            topicPublisher.publish("/topic/" + topic, payload);
         } catch (Exception ex) {
             log.error("MQTT handle error for topic {}: {}", topic, ex.getMessage(), ex);
         }

--- a/src/test/java/se/hydroleaf/mqtt/MqttMessageHandlerWaterTankTest.java
+++ b/src/test/java/se/hydroleaf/mqtt/MqttMessageHandlerWaterTankTest.java
@@ -47,6 +47,7 @@ class MqttMessageHandlerWaterTankTest {
 
         verify(deviceProvisionService).ensureDevice(eq("S01-L01-probe1"), eq(topic));
         verify(recordService).saveRecord(eq("S01-L01-probe1"), any());
+        verify(topicPublisher).publish(eq("/topic/" + topic), eq(payload));
         assertTrue(lastSeen.contains("S01-L01-probe1"));
     }
 
@@ -57,7 +58,18 @@ class MqttMessageHandlerWaterTankTest {
 
         handler.handle(topic, payload);
 
-        verifyNoInteractions(deviceProvisionService, recordService);
+        verifyNoInteractions(deviceProvisionService, recordService, topicPublisher);
+        assertTrue(lastSeen.isEmpty());
+    }
+
+    @Test
+    void invalidJson_isDiscardedWithoutPublishing() {
+        String topic = "waterTank/S01/L01/probe1";
+        String payload = "{"; // malformed JSON
+
+        handler.handle(topic, payload);
+
+        verifyNoInteractions(deviceProvisionService, recordService, topicPublisher);
         assertTrue(lastSeen.isEmpty());
     }
 }


### PR DESCRIPTION
## Summary
- publish MQTT payloads to STOMP only after successful JSON parse and composite id validation
- skip and log malformed messages so they aren't forwarded to topics
- add tests covering valid, missing composite id, and invalid JSON scenarios

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*
- `./mvnw -q test` *(fails: Failed to fetch Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a7fc8d6083288a897f28dcf9d484