### PR TITLE
Validate composite_id before STOMP publish

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
@@ -39,7 +39,6 @@ public class MqttMessageHandler {
     }
 
     public void handle(String topic, String payload) {
-        topicPublisher.publish("/topic/" + topic, payload);
         try {
             JsonNode node = objectMapper.readTree(payload);
 
@@ -55,6 +54,8 @@ public class MqttMessageHandler {
                 }
                 return;
             }
+
+            topicPublisher.publish("/topic/" + topic, payload);
 
             deviceProvisionService.ensureDevice(compositeId, topic);
             recordService.saveRecord(compositeId, node);

--- a/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
+++ b/src/main/java/se/hydroleaf/mqtt/MqttMessageHandler.java
@@ -55,11 +55,11 @@ public class MqttMessageHandler {
                 return;
             }
 
-            topicPublisher.publish("/topic/" + topic, payload);
-
             deviceProvisionService.ensureDevice(compositeId, topic);
             recordService.saveRecord(compositeId, node);
             lastSeen.update(compositeId);
+
+            topicPublisher.publish("/topic/" + topic, payload);
         } catch (Exception ex) {
             log.error("MQTT handle error for topic {}: {}", topic, ex.getMessage(), ex);
         }


### PR DESCRIPTION
## Summary
- Parse MQTT JSON payload before STOMP publishing
- Validate composite_id and publish only after successful validation

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a9176e0883289471171002533784