### PR TITLE
test: enforce SensorData unique constraint

### DIFF
--- a/src/test/java/se/hydroleaf/repository/SensorDataRepositoryTest.java
+++ b/src/test/java/se/hydroleaf/repository/SensorDataRepositoryTest.java
@@ -1,0 +1,67 @@
+package se.hydroleaf.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+import se.hydroleaf.model.Device;
+import se.hydroleaf.model.DeviceGroup;
+import se.hydroleaf.model.SensorData;
+import se.hydroleaf.model.SensorRecord;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class SensorDataRepositoryTest {
+
+    @Autowired
+    private SensorDataRepository sensorDataRepository;
+
+    @Autowired
+    private SensorRecordRepository sensorRecordRepository;
+
+    @Autowired
+    private DeviceRepository deviceRepository;
+
+    @Autowired
+    private DeviceGroupRepository deviceGroupRepository;
+
+    @Test
+    void duplicateRecordAndSensorTypeFails() {
+        DeviceGroup group = new DeviceGroup();
+        group.setMqttTopic("unique-constraint-test-group");
+        group = deviceGroupRepository.save(group);
+
+        Device device = new Device();
+        device.setCompositeId("S01-L01-D01");
+        device.setSystem("S01");
+        device.setLayer("L01");
+        device.setDeviceId("D01");
+        device.setGroup(group);
+        device = deviceRepository.save(device);
+
+        SensorRecord record = new SensorRecord();
+        record.setDevice(device);
+        record.setTimestamp(Instant.now());
+        record = sensorRecordRepository.save(record);
+
+        SensorData first = new SensorData();
+        first.setRecord(record);
+        first.setSensorType("light");
+        first.setValue(1.0);
+        sensorDataRepository.saveAndFlush(first);
+
+        SensorData second = new SensorData();
+        second.setRecord(record);
+        second.setSensorType("light");
+        second.setValue(2.0);
+
+        assertThrows(DataIntegrityViolationException.class, () -> {
+            sensorDataRepository.saveAndFlush(second);
+        });
+    }
+}

--- a/src/test/java/se/hydroleaf/repository/SensorDataRepositoryTest.java
+++ b/src/test/java/se/hydroleaf/repository/SensorDataRepositoryTest.java
@@ -3,6 +3,7 @@ package se.hydroleaf.repository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 import se.hydroleaf.model.Device;
@@ -17,6 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @DataJpaTest
 @ActiveProfiles("test")
 class SensorDataRepositoryTest {
+
+    @MockBean
+    private AggregateRepository aggregateRepository;
 
     @Autowired
     private SensorDataRepository sensorDataRepository;


### PR DESCRIPTION
## Summary
- add DataJpa test to confirm sensor data cannot reuse record+sensorType combination

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bc6f475083288d6f0edbf9ffdae6