### PR TITLE
Handle empty sensor types during migration

### DIFF
--- a/src/main/resources/db/migration/V5__ensure_sensor_data_unique_constraint.sql
+++ b/src/main/resources/db/migration/V5__ensure_sensor_data_unique_constraint.sql
@@ -8,6 +8,9 @@ WITH dup AS (
 )
 DELETE FROM sensor_data WHERE ctid IN (SELECT ctid FROM dup);
 
+-- Remove rows with empty sensor_type before enforcing constraint
+DELETE FROM sensor_data WHERE sensor_type = '';
+
 -- Ensure unique (record_id, sensor_type) pairs in sensor_data
 DO $$
 BEGIN


### PR DESCRIPTION
## Summary
- Remove any `sensor_data` rows with empty `sensor_type` values before applying constraints

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*
- `mvn -q test` *(fails: Network is unreachable for Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c99fbf6c8328a4fbe1ed1b7efe5a