### PR TITLE
Simplify LiveFeedScheduler

### DIFF
--- a/src/main/java/se/hydroleaf/mqtt/TopicPublisher.java
+++ b/src/main/java/se/hydroleaf/mqtt/TopicPublisher.java
@@ -24,6 +24,7 @@ public class TopicPublisher {
 
     public void publish(String destination, String payload) {
         if (publishEnabled) {
+            log.debug("Publishing to {} : {}", destination, payload);
             messagingTemplate.convertAndSend(destination, payload);
         } else {
             if ("/topic/live_now".equalsIgnoreCase(destination)) {

--- a/src/main/java/se/hydroleaf/scheduler/LiveFeedScheduler.java
+++ b/src/main/java/se/hydroleaf/scheduler/LiveFeedScheduler.java
@@ -23,7 +23,6 @@ public class LiveFeedScheduler {
     private final TopicPublisher topicPublisher;
     private final LastSeenRegistry lastSeen;
     private final ObjectMapper objectMapper;
-    private Instant lastInvocation;
     public LiveFeedScheduler(StatusService statusService,
                              TopicPublisher topicPublisher,
                              LastSeenRegistry lastSeen,
@@ -36,38 +35,19 @@ public class LiveFeedScheduler {
 
     @Scheduled(fixedRateString = "${livefeed.rate:2000}")
     public void sendLiveNow() {
-        Instant start = Instant.now();
-        if (log.isDebugEnabled()) {
-            if (lastInvocation != null) {
-                long sinceLast = Duration.between(lastInvocation, start).toMillis();
-                log.debug("sendLiveNow invoked at {} ({} ms since last)", start, sinceLast);
-            } else {
-                log.debug("sendLiveNow invoked at {}", start);
-            }
-        }
-        lastInvocation = start;
-
-        LiveNowSnapshot snapshot = statusService.getLiveNowSnapshot();
-        Instant afterSnapshot = Instant.now();
-        log.debug("getLiveNowSnapshot took {} ms", Duration.between(start, afterSnapshot).toMillis());
-
-        String payload= "{'test':'test'}";
+        log.debug("sendLiveNow invoked");
         try {
-            payload = objectMapper.writeValueAsString(snapshot);
-        } catch (JsonProcessingException e) {
-            log.warn("Failed to serialize LiveNowSnapshot", e);
-            return;
-        }
-        try {
-            Instant sendStart = Instant.now();
+            LiveNowSnapshot snapshot = statusService.getLiveNowSnapshot();
+            log.debug("snapshot ready");
+            String payload = objectMapper.writeValueAsString(snapshot);
             log.debug("STOMP send -> /topic/live_now : {}", payload);
             topicPublisher.publish("/topic/live_now", payload);
-            log.debug("convertAndSend took {} ms", Duration.between(sendStart, Instant.now()).toMillis());
+            log.debug("STOMP send complete");
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize LiveNowSnapshot", e);
         } catch (Exception e) {
             log.warn("sendLiveNow failed: {}", e.getMessage());
         }
-
-        log.debug("sendLiveNow completed in {} ms", Duration.between(start, Instant.now()).toMillis());
     }
 
     @Scheduled(fixedDelay = 10000)


### PR DESCRIPTION
## Summary
- Streamline LiveFeedScheduler by removing detailed timing logs and extraneous state
- Retain essential snapshot publishing with serialization and send error handling
- Add debug log indicating when sendLiveNow scheduler runs
- Add granular debug logs around snapshot serialization and STOMP publishing
- TopicPublisher now logs each publish attempt when publishing is enabled

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a19d7f4bd48328854ccd482b89cc26