### PR TITLE
Fetch distinct system-layer pairs for status snapshot

### DIFF
--- a/src/main/java/se/hydroleaf/repository/DeviceRepository.java
+++ b/src/main/java/se/hydroleaf/repository/DeviceRepository.java
@@ -1,6 +1,7 @@
 package se.hydroleaf.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import se.hydroleaf.model.Device;
 
 import java.util.List;
@@ -8,4 +9,7 @@ import java.util.List;
 public interface DeviceRepository extends JpaRepository<Device, String> {
 
     List<Device> findBySystemAndLayer(String system, String layer);
+
+    @Query("SELECT DISTINCT new se.hydroleaf.repository.SystemLayer(d.system, d.layer) FROM Device d")
+    List<SystemLayer> findDistinctSystemAndLayer();
 }

--- a/src/main/java/se/hydroleaf/repository/SystemLayer.java
+++ b/src/main/java/se/hydroleaf/repository/SystemLayer.java
@@ -1,0 +1,16 @@
+package se.hydroleaf.repository;
+
+/**
+ * Projection representing a distinct system and layer combination for devices.
+ */
+public record SystemLayer(String system, String layer) {
+
+    public String getSystem() {
+        return system;
+    }
+
+    public String getLayer() {
+        return layer;
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add a projection-based query to `DeviceRepository` to obtain distinct system and layer combinations
- Use the distinct system-layer pairs in `StatusService.getLiveNowSnapshot` and generate snapshots per pair
- Introduce helper method `createLayerSnapshot` for building layer snapshots

## Testing
- `mvn -q test` *(fails: Network is unreachable for spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68a2363707f48328b99d6a02d6cb604a