### PR TITLE
Allow configuring scheduler pool size

### DIFF
--- a/src/main/java/se/hydroleaf/config/SchedulerConfig.java
+++ b/src/main/java/se/hydroleaf/config/SchedulerConfig.java
@@ -1,5 +1,6 @@
 package se.hydroleaf.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -8,8 +9,10 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 public class SchedulerConfig {
 
     @Bean
-    public ThreadPoolTaskScheduler scheduler() {
+    public ThreadPoolTaskScheduler scheduler(
+            @Value("${scheduler.pool-size:1}") int poolSize) {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(poolSize);
         scheduler.setThreadNamePrefix("scheduler-");
         scheduler.initialize();
         return scheduler;

--- a/src/main/java/se/hydroleaf/scheduler/LastSeenRegistry.java
+++ b/src/main/java/se/hydroleaf/scheduler/LastSeenRegistry.java
@@ -77,7 +77,7 @@ public class LastSeenRegistry {
     /**
      * Removes entries exceeding max age or size.
      */
-    @Scheduled(fixedDelayString = "${lastseen.cleanup-interval:60000}")
+    @Scheduled(fixedDelayString = "${lastseen.cleanup-interval:60000}", scheduler = "scheduler")
     public void cleanup() {
         enforceLimits();
     }

--- a/src/main/java/se/hydroleaf/scheduler/LiveFeedScheduler.java
+++ b/src/main/java/se/hydroleaf/scheduler/LiveFeedScheduler.java
@@ -34,7 +34,7 @@ public class LiveFeedScheduler {
         this.objectMapper = objectMapper;
     }
 
-    @Scheduled(fixedRateString = "${livefeed.rate:2000}")
+    @Scheduled(fixedRateString = "${livefeed.rate:2000}", scheduler = "scheduler")
     public void sendLiveNow() {
         log.info("sendLiveNow invoked");
         try {
@@ -49,7 +49,7 @@ public class LiveFeedScheduler {
         }
     }
 
-    @Scheduled(fixedDelay = 10000)
+    @Scheduled(fixedDelay = 10000, scheduler = "scheduler")
     public void logLaggingDevices() {
         Instant now = Instant.now();
         lastSeen.forEach((id, ts) -> {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,8 @@ mqtt:
 
 livefeed:
   rate: 2000
+scheduler:
+  pool-size: 4
 server:
   ssl:
     enabled: ${SSL_ENABLED:false}


### PR DESCRIPTION
## Summary
- make scheduler thread pool size configurable via `scheduler.pool-size` property
- ensure scheduled tasks explicitly use the configured scheduler

## Testing
- `./mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a238ebcf748328bd01db5342953a4b