### PR TITLE
Add live snapshot caching with configurable TTL

### DIFF
--- a/src/main/java/se/hydroleaf/config/CacheConfig.java
+++ b/src/main/java/se/hydroleaf/config/CacheConfig.java
@@ -1,0 +1,35 @@
+package se.hydroleaf.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.List;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(
+            @Value("${cache.aggregatedHistory.ttl:5m}") Duration aggregatedHistoryTtl,
+            @Value("${cache.liveNow.ttl:2s}") Duration liveNowTtl
+    ) {
+        CaffeineCacheManager manager = new CaffeineCacheManager();
+        manager.setCacheNames(List.of("aggregatedHistory", "liveNow"));
+        manager.registerCustomCache("aggregatedHistory",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(aggregatedHistoryTtl)
+                        .maximumSize(500)
+                        .build());
+        manager.registerCustomCache("liveNow",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(liveNowTtl)
+                        .maximumSize(500)
+                        .build());
+        return manager;
+    }
+}

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -1,6 +1,7 @@
 package se.hydroleaf.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import se.hydroleaf.dto.snapshot.LiveNowSnapshot;
@@ -101,6 +102,7 @@ public class StatusService {
     /**
      * Collects the latest readings for all systems and layers and assembles a snapshot.
      */
+    @Cacheable(cacheNames = "liveNow", key = "'default'", condition = "@environment.getProperty('cache.liveNow.enabled','true') == 'true'")
     public LiveNowSnapshot getLiveNowSnapshot() {
         List<LiveNowRow> sensorRows = sensorDataRepository.fetchLatestSensorAverages(SENSOR_TYPES);
         List<LiveNowRow> actuatorRows = actuatorStatusRepository.fetchLatestActuatorAverages(ACTUATOR_TYPES);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,13 +20,18 @@ spring:
     open-in-view: false
   cache:
     type: caffeine
-    cache-names: aggregatedHistory
-    caffeine:
-      spec: maximumSize=500,expireAfterWrite=5m
+    cache-names: aggregatedHistory, liveNow
   flyway:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration
+
+cache:
+  aggregatedHistory:
+    ttl: 5m
+  liveNow:
+    ttl: 2s
+    enabled: true
 mqtt:
   brokerUri: ${MQTT_BROKER:tcp://100.113.16.30:1883}
   clientId: hydroleaf-backend


### PR DESCRIPTION
## Summary
- cache live snapshot results with Caffeine
- expose TTL and enable toggle through configuration
- register cache manager for liveNow and aggregatedHistory

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3)*

------
https://chatgpt.com/codex/tasks/task_e_68a24276efb48328af24e5a583c1b22c