### PR TITLE
refactor: remove unused aggregate queries

### DIFF
--- a/src/main/java/se/hydroleaf/repository/ActuatorStatusRepositoryCustom.java
+++ b/src/main/java/se/hydroleaf/repository/ActuatorStatusRepositoryCustom.java
@@ -1,9 +1,7 @@
 package se.hydroleaf.repository;
 
-import java.util.Map;
-
 public interface ActuatorStatusRepositoryCustom {
+
     AverageCount getLatestActuatorAverage(String system, String layer, String actuatorType);
-    Map<String, AverageCount> getLatestActuatorAverages(String system, String layer);
 }
 

--- a/src/main/java/se/hydroleaf/repository/ActuatorStatusRepositoryImpl.java
+++ b/src/main/java/se/hydroleaf/repository/ActuatorStatusRepositoryImpl.java
@@ -2,8 +2,6 @@ package se.hydroleaf.repository;
 
 import org.springframework.stereotype.Repository;
 
-import java.util.Map;
-
 @Repository
 public class ActuatorStatusRepositoryImpl implements ActuatorStatusRepositoryCustom {
 
@@ -16,11 +14,6 @@ public class ActuatorStatusRepositoryImpl implements ActuatorStatusRepositoryCus
     @Override
     public AverageCount getLatestActuatorAverage(String system, String layer, String actuatorType) {
         return aggregateRepository.getLatestAverage(system, layer, actuatorType, "actuator_status");
-    }
-
-    @Override
-    public Map<String, AverageCount> getLatestActuatorAverages(String system, String layer) {
-        return aggregateRepository.getLatestAverages(system, layer, "actuator_status");
     }
 }
 

--- a/src/main/java/se/hydroleaf/repository/SensorDataRepositoryCustom.java
+++ b/src/main/java/se/hydroleaf/repository/SensorDataRepositoryCustom.java
@@ -1,9 +1,7 @@
 package se.hydroleaf.repository;
 
-import java.util.Map;
-
 public interface SensorDataRepositoryCustom {
+
     AverageCount getLatestAverage(String system, String layer, String sensorType);
-    Map<String, AverageCount> getLatestAverages(String system, String layer);
 }
 

--- a/src/main/java/se/hydroleaf/repository/SensorDataRepositoryImpl.java
+++ b/src/main/java/se/hydroleaf/repository/SensorDataRepositoryImpl.java
@@ -2,8 +2,6 @@ package se.hydroleaf.repository;
 
 import org.springframework.stereotype.Repository;
 
-import java.util.Map;
-
 @Repository
 public class SensorDataRepositoryImpl implements SensorDataRepositoryCustom {
 
@@ -16,11 +14,6 @@ public class SensorDataRepositoryImpl implements SensorDataRepositoryCustom {
     @Override
     public AverageCount getLatestAverage(String system, String layer, String sensorType) {
         return aggregateRepository.getLatestAverage(system, layer, sensorType, "sensor_data");
-    }
-
-    @Override
-    public Map<String, AverageCount> getLatestAverages(String system, String layer) {
-        return aggregateRepository.getLatestAverages(system, layer, "sensor_data");
     }
 }
 


### PR DESCRIPTION
## Summary
- drop leftover bulk-average methods from custom repositories
- remove unused aggregate query from `AggregateRepository`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2440e46c8832889f30d17082071ef