### PR TITLE
chore: add indexes for live now queries

### DIFF
--- a/src/main/resources/db/migration/V6__live_now_indexes.sql
+++ b/src/main/resources/db/migration/V6__live_now_indexes.sql
@@ -1,0 +1,11 @@
+-- Index supporting device and time lookups on sensor_record
+CREATE INDEX IF NOT EXISTS idx_sr_device_ts ON sensor_record (device_composite_id, record_time DESC);
+
+-- Index for efficient sensor_data lookups by record and type
+CREATE INDEX IF NOT EXISTS idx_sd_record_type ON sensor_data (record_id, sensor_type);
+
+-- Index supporting device and actuator type queries ordered by timestamp
+CREATE INDEX IF NOT EXISTS idx_act_device_type_ts ON actuator_status (composite_id, actuator_type, status_time DESC);
+
+-- Index to speed up device queries by system and layer
+CREATE INDEX IF NOT EXISTS idx_device_system_layer ON device (system, layer);


### PR DESCRIPTION
## Summary
- add indexes to support live now queries on sensor_record, sensor_data, actuator_status, and device
- fix actuator_status index to use existing composite_id and status_time columns

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a24114a6188328be61dbde092d63f1