### PR TITLE
Fix LiveNow snapshot query mappings

### DIFF
--- a/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
@@ -17,37 +17,34 @@ public interface SensorDataRepository extends JpaRepository<SensorData, Long>, S
     Optional<SensorData> findTopByRecord_DeviceCompositeIdAndSensorTypeOrderByRecord_TimestampDesc(String compositeId,
                                                                                                    String sensorType);
 
+    /**
+     * Batch query returning the latest average per system/layer and sensor type.
+     */
     @Query(value = """
             WITH latest AS (
               SELECT
-                d.system         AS system,
-                d.layer          AS layer,
-                sr.device_composite_id AS composite_id,
-                sd.sensor_type   AS sensor_type,
-                sd.unit          AS unit,
-                sd.sensor_value  AS val,
-                sr.record_time   AS record_time,
+                d.system,
+                d.layer,
+                sd.sensor_type,
+                sd.sensor_value AS value,
                 ROW_NUMBER() OVER (
-                  PARTITION BY d.system, d.layer, sr.device_composite_id, sd.sensor_type
+                  PARTITION BY sr.device_composite_id, sd.sensor_type
                   ORDER BY sr.record_time DESC
                 ) AS rn
-              FROM sensor_record sr
-              JOIN sensor_data sd ON sd.record_id = sr.id
+              FROM sensor_data sd
+              JOIN sensor_record sr ON sr.id = sd.record_id
               JOIN device d ON d.composite_id = sr.device_composite_id
-              WHERE sd.sensor_type IN (:types)
-                AND sd.sensor_value IS NOT NULL
+              WHERE sd.sensor_type = ANY(:types)
             )
             SELECT
-              system,
-              layer,
-              sensor_type,
-              unit,
-              AVG(val)                          AS avg_value,
-              CAST(COUNT(val) AS BIGINT)        AS device_count,
-              MAX(record_time)                  AS record_time
+              system AS system,
+              layer AS layer,
+              sensor_type AS type,
+              AVG(value) AS average,
+              COUNT(*)::bigint AS count
             FROM latest
             WHERE rn = 1
-            GROUP BY system, layer, sensor_type, unit
+            GROUP BY system, layer, sensor_type
             """, nativeQuery = true)
     List<LiveNowRow> fetchLatestSensorAverages(@Param("types") List<String> types);
 }

--- a/src/main/java/se/hydroleaf/repository/dto/LiveNowRow.java
+++ b/src/main/java/se/hydroleaf/repository/dto/LiveNowRow.java
@@ -1,13 +1,12 @@
 package se.hydroleaf.repository.dto;
 
-import java.time.Instant;
-
-public record LiveNowRow(
-        String system,
-        String layer,
-        String sensorType,
-        String unit,
-        Double avgValue,
-        Long deviceCount,
-        Instant recordTime
-) {}
+/**
+ * Projection for live-now aggregation rows.
+ */
+public interface LiveNowRow {
+    String getSystem();
+    String getLayer();
+    String getType();
+    Double getAverage();
+    Long getCount();
+}


### PR DESCRIPTION
## Summary
- Switch to interface-based `LiveNowRow` projection for sensor/actuator aggregates
- Batch queries now return system/layer/type averages and counts for live snapshot
- Refactor `StatusService` aggregation to use the new projection and in-memory assembly

## Testing
- `mvn -q -e -DskipTests=false test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a23af9f4b48328b585a2391c3308dc