### PR TITLE
Add index for actuator_status table

### DIFF
--- a/src/main/resources/db/migration/V9__actuator_status_composite_type_time_idx.sql
+++ b/src/main/resources/db/migration/V9__actuator_status_composite_type_time_idx.sql
@@ -1,0 +1,3 @@
+-- Index covering DISTINCT and ORDER BY columns on actuator_status
+CREATE INDEX idx_actuator_status_composite_type_time
+ON actuator_status (composite_id, actuator_type, status_time DESC);


### PR DESCRIPTION
## Summary
- add migration creating index on actuator_status covering composite id, type, and status time

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org...)*
- `psql -c "EXPLAIN ANALYZE SELECT 1"` *(fails: command not found: psql)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a507b348832896b824773d2ed821