### PR TITLE
Use latest_sensor_value for status averages

### DIFF
--- a/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorDataRepository.java
@@ -20,6 +20,9 @@ public interface SensorDataRepository extends JpaRepository<SensorData, Long> {
 
     /**
      * Batch query returning the latest average per system/layer and sensor type.
+     *
+     * <p>Uses the materialized {@code latest_sensor_value} table maintained by
+     * database triggers rather than a window function over all sensor_data.</p>
      */
     @Query(value = """
             SELECT

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -30,7 +30,9 @@ import java.util.stream.Stream;
  *
  * <p>The previous implementation queried one system/layer at a time. The new
  * approach performs two bulk queries – one for sensors and one for actuators –
- * and then assembles the snapshot in-memory.</p>
+ * and then assembles the snapshot in-memory. Sensor readings are sourced from
+ * the materialized {@code latest_sensor_value} table populated by database
+ * triggers.</p>
  */
 @Slf4j
 @Service

--- a/src/test/java/se/hydroleaf/service/StatusServiceIntegrationTest.java
+++ b/src/test/java/se/hydroleaf/service/StatusServiceIntegrationTest.java
@@ -22,9 +22,6 @@ class StatusServiceIntegrationTest {
     private StatusService statusService;
 
     @Autowired
-    private SensorDataRepository sensorDataRepository;
-
-    @Autowired
     private ActuatorStatusRepository actuatorStatusRepository;
 
     @Autowired
@@ -32,9 +29,6 @@ class StatusServiceIntegrationTest {
 
     @Autowired
     private DeviceRepository deviceRepository;
-
-    @Autowired
-    private SensorRecordRepository sensorRecordRepository;
 
     @Autowired
     private LatestSensorValueRepository latestSensorValueRepository;
@@ -54,18 +48,6 @@ class StatusServiceIntegrationTest {
         device = deviceRepository.save(device);
 
         Instant now = Instant.now();
-
-        SensorRecord record = new SensorRecord();
-        record.setDevice(device);
-        record.setTimestamp(now);
-        record = sensorRecordRepository.save(record);
-
-        SensorData data = new SensorData();
-        data.setRecord(record);
-        data.setSensorType("light");
-        data.setValue(5.0);
-        data.setUnit("lux");
-        sensorDataRepository.save(data);
 
         LatestSensorValue latest = LatestSensorValue.builder()
                 .device(device)


### PR DESCRIPTION
## Summary
- clarify `fetchLatestSensorAverages` to rely on `latest_sensor_value` table instead of window functions
- document new data source in `StatusService`
- streamline `StatusServiceIntegrationTest` to seed `latest_sensor_value` directly

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a40c5333888328888f65a688ac96b3