### PR TITLE
Remove duplicate Flyway migration version 8

### DIFF
--- a/src/main/resources/db/migration/V8__actuator_status_composite_type_time_index.sql
+++ b/src/main/resources/db/migration/V8__actuator_status_composite_type_time_index.sql
@@ -1,4 +1,0 @@
--- Index covering DISTINCT and ORDER BY columns on actuator_status
-DROP INDEX IF EXISTS idx_act_device_type_ts;
-CREATE INDEX idx_actuator_status_composite_type_time
-ON actuator_status (composite_id, actuator_type, status_time DESC);


### PR DESCRIPTION
## Summary
- delete outdated actuator_status Flyway migration to resolve version 8 conflict

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68a40d44f5f08328aa3e94943620a990