### PR TITLE
Upsert latest sensor values after recording

### DIFF
--- a/src/main/java/se/hydroleaf/repository/LatestSensorValueRepository.java
+++ b/src/main/java/se/hydroleaf/repository/LatestSensorValueRepository.java
@@ -3,10 +3,14 @@ package se.hydroleaf.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import se.hydroleaf.model.LatestSensorValue;
 
+import java.util.Optional;
+
 /**
  * Repository for LatestSensorValue. Primarily used in tests to populate the
  * latest_sensor_value table when database triggers are not available.
  */
 public interface LatestSensorValueRepository extends JpaRepository<LatestSensorValue, Long> {
+
+    Optional<LatestSensorValue> findByDevice_CompositeIdAndSensorType(String compositeId, String sensorType);
 }
 


### PR DESCRIPTION
## Summary
- upsert latest_sensor_value entries when saving sensor records
- add repository helper for querying latest sensor values
- test upsert behavior of RecordService

## Testing
- `./mvnw -q test` *(fails: wget failed to fetch Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68a4825659cc832885bcecc17dc59a7a