### PR TITLE
Add migration to rename sensor value columns

### DIFF
--- a/src/main/resources/db/migration/V12__rename_sensor_value_columns.sql
+++ b/src/main/resources/db/migration/V12__rename_sensor_value_columns.sql
@@ -1,0 +1,7 @@
+ALTER TABLE sensor_value RENAME TO sensor_value_history;
+ALTER TABLE sensor_value_history RENAME COLUMN sensor_name TO sensor_type;
+ALTER TABLE sensor_value_history RENAME COLUMN ts TO value_time;
+ALTER TABLE sensor_value_history RENAME COLUMN value TO sensor_value;
+ALTER TABLE sensor_value_history RENAME CONSTRAINT fk_sv_device TO fk_svh_device;
+ALTER INDEX idx_sv_device_sensor_ts RENAME TO idx_svh_device_sensor_time;
+ALTER INDEX idx_sv_system_layer RENAME TO idx_svh_system_layer;


### PR DESCRIPTION
## Summary
- rename sensor_value table to sensor_value_history
- rename related columns, indexes and foreign key to new sensor_value_history naming

## Testing
- `./mvnw -q -Dflyway.url=jdbc:h2:mem:test -Dflyway.user=sa -Dflyway.password= -Dflyway.cleanDisabled=true org.flywaydb:flyway-maven-plugin:11.11.0:migrate` *(fails: wget failed to fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_68a4957b6b38832891771bb0b4ce37c7