### PR TITLE
Rename sensor data to sensor reading

### DIFF
--- a/src/main/java/se/hydroleaf/model/SensorReading.java
+++ b/src/main/java/se/hydroleaf/model/SensorReading.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 
 @Entity
 @Table(
-        name = "sensor_data",
+        name = "sensor_reading",
         uniqueConstraints = {
                 // Prevent duplicate (record, sensor_type) rows.
                 @UniqueConstraint(name = "ux_data_record_type", columnNames = {"record_id", "sensor_type"})
@@ -27,7 +27,7 @@ import lombok.ToString;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class SensorData {
+public class SensorReading {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/se/hydroleaf/model/SensorRecord.java
+++ b/src/main/java/se/hydroleaf/model/SensorRecord.java
@@ -22,8 +22,8 @@ import java.util.List;
 )
 @Getter
 @Setter
-@EqualsAndHashCode(exclude = {"device", "values", "healthItems"})
-@ToString(exclude = {"device", "values", "healthItems"})
+@EqualsAndHashCode(exclude = {"device", "readings", "healthItems"})
+@ToString(exclude = {"device", "readings", "healthItems"})
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -47,10 +47,10 @@ public class SensorRecord {
     private Instant timestamp;
 
     /**
-     * Record contains many values (measurements).
+     * Record contains many readings (measurements).
      */
     @OneToMany(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SensorData> values = new ArrayList<>();
+    private List<SensorReading> readings = new ArrayList<>();
 
     /**
      * Record can also contain health items.

--- a/src/main/java/se/hydroleaf/repository/SensorAggregationRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorAggregationRepository.java
@@ -19,7 +19,7 @@ public interface SensorAggregationRepository extends JpaRepository<SensorRecord,
               time_bucket(:bucketSec * INTERVAL '1 second', sr.record_time) AS bucket_time,
               AVG(sd.sensor_value) AS avg_value
             FROM sensor_record sr
-            JOIN sensor_data sd ON sd.record_id = sr.id
+            JOIN sensor_reading sd ON sd.record_id = sr.id
             WHERE sr.device_composite_id = :compositeId
               AND sr.record_time >= :fromTs
               AND sr.record_time <  :toTs
@@ -43,7 +43,7 @@ public interface SensorAggregationRepository extends JpaRepository<SensorRecord,
               date_trunc('second', to_timestamp(floor(EXTRACT(EPOCH FROM sr.record_time) / :bucketSec) * :bucketSec)) AS bucket_time,
               AVG(sd.sensor_value) AS avg_value
             FROM sensor_record sr
-            JOIN sensor_data sd ON sd.record_id = sr.id
+            JOIN sensor_reading sd ON sd.record_id = sr.id
             WHERE sr.device_composite_id = :compositeId
               AND sr.record_time >= :fromTs
               AND sr.record_time <  :toTs

--- a/src/main/java/se/hydroleaf/repository/SensorReadingRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorReadingRepository.java
@@ -3,26 +3,26 @@ package se.hydroleaf.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import se.hydroleaf.model.SensorData;
+import se.hydroleaf.model.SensorReading;
 import se.hydroleaf.repository.dto.LiveNowRow;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-public interface SensorDataRepository extends JpaRepository<SensorData, Long> {
+public interface SensorReadingRepository extends JpaRepository<SensorReading, Long> {
 
     /**
      * Latest sensor reading for a device and sensor type.
      */
-    Optional<SensorData> findTopByRecord_DeviceCompositeIdAndSensorTypeOrderByRecord_TimestampDesc(String compositeId,
-                                                                                                   String sensorType);
+    Optional<SensorReading> findTopByRecord_DeviceCompositeIdAndSensorTypeOrderByRecord_TimestampDesc(String compositeId,
+                                                                                                      String sensorType);
 
     /**
      * Batch query returning the latest average per system/layer and sensor type.
      *
      * <p>Uses the materialized {@code latest_sensor_value} table maintained by
-     * database triggers rather than a window function over all sensor_data.</p>
+     * database triggers rather than a window function over all sensor_reading.</p>
      */
     @Query(value = """
             SELECT

--- a/src/main/java/se/hydroleaf/service/StatusService.java
+++ b/src/main/java/se/hydroleaf/service/StatusService.java
@@ -11,7 +11,7 @@ import se.hydroleaf.dto.summary.StatusAllAverageResponse;
 import se.hydroleaf.dto.summary.StatusAverageResponse;
 import se.hydroleaf.dto.summary.WaterTankSummary;
 import se.hydroleaf.repository.ActuatorStatusRepository;
-import se.hydroleaf.repository.SensorDataRepository;
+import se.hydroleaf.repository.SensorReadingRepository;
 import se.hydroleaf.repository.dto.LiveNowRow;
 import se.hydroleaf.model.DeviceType;
 
@@ -52,12 +52,12 @@ public class StatusService {
 
     private static final List<DeviceType> ACTUATOR_TYPES = List.of(DeviceType.AIR_PUMP);
 
-    private final SensorDataRepository sensorDataRepository;
+    private final SensorReadingRepository sensorReadingRepository;
     private final ActuatorStatusRepository actuatorStatusRepository;
 
-    public StatusService(SensorDataRepository sensorDataRepository,
+    public StatusService(SensorReadingRepository sensorReadingRepository,
                          ActuatorStatusRepository actuatorStatusRepository) {
-        this.sensorDataRepository = sensorDataRepository;
+        this.sensorReadingRepository = sensorReadingRepository;
         this.actuatorStatusRepository = actuatorStatusRepository;
     }
 
@@ -80,7 +80,7 @@ public class StatusService {
             String resultUnit = row != null && row.getUnit() != null ? row.getUnit() : unit;
             return new StatusAverageResponse(avg, resultUnit, count);
         } else {
-            List<LiveNowRow> rows = sensorDataRepository.fetchLatestSensorAverages(List.of(type.getName()));
+            List<LiveNowRow> rows = sensorReadingRepository.fetchLatestSensorAverages(List.of(type.getName()));
             LiveNowRow row = rows.stream()
                     .filter(r -> r.getSystem() != null && r.getLayer() != null
                             && system.equalsIgnoreCase(r.getSystem())
@@ -96,7 +96,7 @@ public class StatusService {
     }
 
     public StatusAllAverageResponse getAllAverages(String system, String layer) {
-        List<LiveNowRow> sensorRows = sensorDataRepository.fetchLatestSensorAverages(
+        List<LiveNowRow> sensorRows = sensorReadingRepository.fetchLatestSensorAverages(
                 SENSOR_TYPES.stream().map(DeviceType::getName).toList());
         List<LiveNowRow> actuatorRows = actuatorStatusRepository.fetchLatestActuatorAverages(
                 ACTUATOR_TYPES.stream().map(DeviceType::getName).toList());
@@ -154,7 +154,7 @@ public class StatusService {
      * Collects the latest readings for all systems and layers and assembles a snapshot.
      */
     public LiveNowSnapshot getLiveNowSnapshot() {
-        List<LiveNowRow> sensorRows = sensorDataRepository.fetchLatestSensorAverages(
+        List<LiveNowRow> sensorRows = sensorReadingRepository.fetchLatestSensorAverages(
                 SENSOR_TYPES.stream().map(DeviceType::getName).toList());
         List<LiveNowRow> actuatorRows = actuatorStatusRepository.fetchLatestActuatorAverages(
                 ACTUATOR_TYPES.stream().map(DeviceType::getName).toList());

--- a/src/main/resources/db/migration/V11__latest_sensor_health_table.sql
+++ b/src/main/resources/db/migration/V11__latest_sensor_health_table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS latest_sensor_health (
     composite_id VARCHAR(128) NOT NULL,
     sensor_name VARCHAR(64) NOT NULL,
-    value DOUBLE PRECISION,
+    sensor_value DOUBLE PRECISION,
     unit VARCHAR(32),
     health_ok BOOLEAN,
     ts TIMESTAMPTZ NOT NULL,

--- a/src/main/resources/db/migration/V4__sensor_aggregation_indexes.sql
+++ b/src/main/resources/db/migration/V4__sensor_aggregation_indexes.sql
@@ -1,6 +1,6 @@
 -- Index supporting sensorType filtering and non-null values
-CREATE INDEX IF NOT EXISTS ix_sensor_data_type_record_notnull
-    ON sensor_data (sensor_type, record_id)
+CREATE INDEX IF NOT EXISTS ix_sensor_reading_type_record_notnull
+    ON sensor_reading (sensor_type, record_id)
     WHERE sensor_value IS NOT NULL;
 
 -- Expression index for common 1 minute bucket to speed up aggregation

--- a/src/main/resources/db/migration/V6__live_now_indexes.sql
+++ b/src/main/resources/db/migration/V6__live_now_indexes.sql
@@ -1,8 +1,8 @@
 -- Index supporting device and time lookups on sensor_record
 CREATE INDEX IF NOT EXISTS idx_sr_device_ts ON sensor_record (device_composite_id, record_time DESC);
 
--- Index for efficient sensor_data lookups by record and type
-CREATE INDEX IF NOT EXISTS idx_sd_record_type ON sensor_data (record_id, sensor_type);
+-- Index for efficient sensor_reading lookups by record and type
+CREATE INDEX IF NOT EXISTS idx_sreading_record_type ON sensor_reading (record_id, sensor_type);
 
 -- Index supporting device and actuator type queries ordered by timestamp
 CREATE INDEX IF NOT EXISTS idx_act_device_type_ts ON actuator_status (composite_id, actuator_type, status_time DESC);

--- a/src/main/resources/db/migration/V7__sensor_data_type_record_index.sql
+++ b/src/main/resources/db/migration/V7__sensor_data_type_record_index.sql
@@ -1,2 +1,0 @@
--- Index to support latest sensor average queries by sensor type and record
-CREATE INDEX IF NOT EXISTS idx_sd_type_record ON sensor_data (sensor_type, record_id);

--- a/src/main/resources/db/migration/V7__sensor_reading_type_record_index.sql
+++ b/src/main/resources/db/migration/V7__sensor_reading_type_record_index.sql
@@ -1,0 +1,2 @@
+-- Index to support latest sensor average queries by sensor type and record
+CREATE INDEX IF NOT EXISTS idx_sreading_type_record ON sensor_reading (sensor_type, record_id);

--- a/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/StatusControllerTest.java
@@ -57,7 +57,7 @@ class StatusControllerTest {
     }
 
     @Test
-    void getAverageEndpointReturnsWaterTankSensorData() throws Exception {
+    void getAverageEndpointReturnsWaterTankSensorReadingData() throws Exception {
         when(statusService.getAverage("sys", "layer", "dissolvedOxygen"))
                 .thenReturn(new StatusAverageResponse(5.5, "mg/L", 4L));
 

--- a/src/test/java/se/hydroleaf/repository/LatestAveragesRepositoryTest.java
+++ b/src/test/java/se/hydroleaf/repository/LatestAveragesRepositoryTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @ActiveProfiles("test")
 class LatestAveragesRepositoryTest {
     @Autowired
-    private SensorDataRepository sensorDataRepository;
+    private SensorReadingRepository sensorReadingRepository;
 
     @Autowired
     private ActuatorStatusRepository actuatorStatusRepository;
@@ -76,7 +76,7 @@ class LatestAveragesRepositoryTest {
 
         latestSensorValueRepository.flush();
 
-        List<LiveNowRow> rows = sensorDataRepository.fetchLatestSensorAverages(List.of("temperature"));
+        List<LiveNowRow> rows = sensorReadingRepository.fetchLatestSensorAverages(List.of("temperature"));
         assertEquals(1, rows.size());
         LiveNowRow row = rows.get(0);
 

--- a/src/test/java/se/hydroleaf/repository/SensorReadingRepositoryTest.java
+++ b/src/test/java/se/hydroleaf/repository/SensorReadingRepositoryTest.java
@@ -7,7 +7,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 import se.hydroleaf.model.Device;
 import se.hydroleaf.model.DeviceGroup;
-import se.hydroleaf.model.SensorData;
+import se.hydroleaf.model.SensorReading;
 import se.hydroleaf.model.SensorRecord;
 
 import java.time.Instant;
@@ -16,10 +16,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
 @ActiveProfiles("test")
-class SensorDataRepositoryTest {
+class SensorReadingRepositoryTest {
 
     @Autowired
-    private SensorDataRepository sensorDataRepository;
+    private SensorReadingRepository sensorReadingRepository;
 
     @Autowired
     private SensorRecordRepository sensorRecordRepository;
@@ -49,19 +49,19 @@ class SensorDataRepositoryTest {
         record.setTimestamp(Instant.now());
         record = sensorRecordRepository.save(record);
 
-        SensorData first = new SensorData();
+        SensorReading first = new SensorReading();
         first.setRecord(record);
         first.setSensorType("light");
         first.setValue(1.0);
-        sensorDataRepository.saveAndFlush(first);
+        sensorReadingRepository.saveAndFlush(first);
 
-        SensorData second = new SensorData();
+        SensorReading second = new SensorReading();
         second.setRecord(record);
         second.setSensorType("light");
         second.setValue(2.0);
 
         assertThrows(DataIntegrityViolationException.class, () -> {
-            sensorDataRepository.saveAndFlush(second);
+            sensorReadingRepository.saveAndFlush(second);
         });
     }
 }

--- a/src/test/java/se/hydroleaf/service/RecordServiceDeviceTests.java
+++ b/src/test/java/se/hydroleaf/service/RecordServiceDeviceTests.java
@@ -14,7 +14,7 @@ import se.hydroleaf.model.LatestSensorValue;
 import se.hydroleaf.repository.ActuatorStatusRepository;
 import se.hydroleaf.repository.DeviceGroupRepository;
 import se.hydroleaf.repository.DeviceRepository;
-import se.hydroleaf.repository.SensorDataRepository;
+import se.hydroleaf.repository.SensorReadingRepository;
 import se.hydroleaf.repository.SensorHealthItemRepository;
 import se.hydroleaf.repository.LatestSensorValueRepository;
 import se.hydroleaf.model.DeviceType;
@@ -27,7 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Integration test for RecordService with Option-1 model:
  * - Device PK = composite_id
- * - RecordService.saveRecord persists SensorRecord + SensorData (+ optional actuator status)
+ * - RecordService.saveRecord persists SensorRecord + SensorReading (+ optional actuator status)
  * Notes:
  * - All comments are in English only per your preference.
  */
@@ -46,7 +46,7 @@ class RecordServiceDeviceTests {
     @Autowired
     DeviceGroupRepository deviceGroupRepository;
     @Autowired
-    SensorDataRepository sensorDataRepository;
+    SensorReadingRepository sensorReadingRepository;
     @Autowired
     ActuatorStatusRepository actuatorStatusRepository;
     @Autowired
@@ -127,7 +127,7 @@ class RecordServiceDeviceTests {
                         .unit("lx")
                         .valueTime(Instant.parse("2025-01-01T00:00:00Z"))
                         .build());
-        List<LiveNowRow> rows = sensorDataRepository.fetchLatestSensorAverages(List.of(DeviceType.LIGHT.getName()));
+        List<LiveNowRow> rows = sensorReadingRepository.fetchLatestSensorAverages(List.of(DeviceType.LIGHT.getName()));
         LiveNowRow lightAvg = rows.stream()
                 .filter(r -> "S02".equals(r.getSystem()) && "L02".equals(r.getLayer()))
                 .findFirst().orElse(null);
@@ -136,7 +136,7 @@ class RecordServiceDeviceTests {
         assertTrue(lightAvg.getDeviceCount() >= 1);
 
         // sensorType persistence check (ph sensor without sensorName)
-        assertTrue(sensorDataRepository.findAll().stream()
+        assertTrue(sensorReadingRepository.findAll().stream()
                 .anyMatch(d -> "ph".equals(d.getSensorType())));
 
         // Pump status row should be inserted (airPump=false)
@@ -216,7 +216,7 @@ class RecordServiceDeviceTests {
 
         recordService.saveRecord(compositeId, objectMapper.readTree(json));
 
-        var data = sensorDataRepository.findAll().stream()
+        var data = sensorReadingRepository.findAll().stream()
                 .filter(d -> compositeId.equals(d.getRecord().getDevice().getCompositeId()))
                 .toList();
         assertEquals(1, data.size());
@@ -242,7 +242,7 @@ class RecordServiceDeviceTests {
 
         recordService.saveRecord(compositeId, objectMapper.readTree(json));
 
-        var data = sensorDataRepository.findAll().stream()
+        var data = sensorReadingRepository.findAll().stream()
                 .filter(d -> compositeId.equals(d.getRecord().getDevice().getCompositeId()))
                 .toList();
         assertEquals(1, data.size());

--- a/src/test/java/se/hydroleaf/service/RecordServiceLatestTests.java
+++ b/src/test/java/se/hydroleaf/service/RecordServiceLatestTests.java
@@ -11,9 +11,9 @@ import se.hydroleaf.model.DeviceGroup;
 import se.hydroleaf.repository.DeviceGroupRepository;
 import se.hydroleaf.repository.DeviceRepository;
 import se.hydroleaf.repository.ActuatorStatusRepository;
-import se.hydroleaf.repository.SensorDataRepository;
+import se.hydroleaf.repository.SensorReadingRepository;
 import se.hydroleaf.model.ActuatorStatus;
-import se.hydroleaf.model.SensorData;
+import se.hydroleaf.model.SensorReading;
 
 import java.time.Instant;
 
@@ -29,7 +29,7 @@ class RecordServiceLatestTests {
     @Autowired RecordService recordService;
     @Autowired DeviceRepository deviceRepository;
     @Autowired DeviceGroupRepository deviceGroupRepository;
-    @Autowired SensorDataRepository sensorDataRepository;
+    @Autowired SensorReadingRepository sensorReadingRepository;
     @Autowired ActuatorStatusRepository actuatorStatusRepository;
 
     private DeviceGroup ensureGroup() {
@@ -69,7 +69,7 @@ class RecordServiceLatestTests {
                 """;
         recordService.saveRecord(compositeId, objectMapper.readTree(first));
 
-        SensorData lsv = sensorDataRepository
+        SensorReading lsv = sensorReadingRepository
                 .findTopByRecord_DeviceCompositeIdAndSensorTypeOrderByRecord_TimestampDesc(compositeId, "light")
                 .orElseThrow();
         assertEquals(10.0, lsv.getValue());
@@ -91,7 +91,7 @@ class RecordServiceLatestTests {
                 """;
         recordService.saveRecord(compositeId, objectMapper.readTree(second));
 
-        SensorData lsv2 = sensorDataRepository
+        SensorReading lsv2 = sensorReadingRepository
                 .findTopByRecord_DeviceCompositeIdAndSensorTypeOrderByRecord_TimestampDesc(compositeId, "light")
                 .orElseThrow();
         assertEquals(15.5, lsv2.getValue());

--- a/src/test/java/se/hydroleaf/service/RecordServiceSpectralTests.java
+++ b/src/test/java/se/hydroleaf/service/RecordServiceSpectralTests.java
@@ -9,7 +9,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import se.hydroleaf.model.Device;
 import se.hydroleaf.model.DeviceGroup;
-import se.hydroleaf.model.SensorData;
+import se.hydroleaf.model.SensorReading;
 import se.hydroleaf.model.SensorRecord;
 import se.hydroleaf.repository.DeviceGroupRepository;
 import se.hydroleaf.repository.DeviceRepository;
@@ -61,7 +61,7 @@ class RecordServiceSpectralTests {
     }
 
     @Test
-    void saves_record_with_empty_values_and_no_sensor_data() throws Exception {
+    void saves_record_with_empty_values_and_no_sensor_readings() throws Exception {
         String compositeId = "S01-L01-G01";
         ensureDevice(compositeId);
 
@@ -76,11 +76,11 @@ class RecordServiceSpectralTests {
 
         List<SensorRecord> records = recordRepository.findAll();
         assertEquals(1, records.size(), "one record should be stored");
-        assertTrue(records.get(0).getValues().isEmpty(), "no SensorData expected");
+        assertTrue(records.get(0).getReadings().isEmpty(), "no SensorReading expected");
     }
 
     @Test
-    void saves_named_spectral_channels_as_separate_sensor_data() throws Exception {
+    void saves_named_spectral_channels_as_separate_sensor_readings() throws Exception {
         String compositeId = "S01-L01-esp32-01";
         ensureDevice(compositeId);
 
@@ -99,7 +99,7 @@ class RecordServiceSpectralTests {
 
         List<SensorRecord> records = recordRepository.findAll();
         assertEquals(1, records.size(), "one record should be stored");
-        List<SensorData> values = records.get(0).getValues();
+        List<SensorReading> values = records.get(0).getReadings();
         assertEquals(3, values.size(), "three spectral channels expected");
 
         // quick sanity on names and values
@@ -128,7 +128,7 @@ class RecordServiceSpectralTests {
 
         List<SensorRecord> records = recordRepository.findAll();
         assertEquals(1, records.size());
-        List<SensorData> values = records.get(0).getValues();
+        List<SensorReading> values = records.get(0).getReadings();
         assertEquals(4, values.size());
         assertTrue(values.stream().anyMatch(v -> "light".equals(v.getSensorType())));
         assertTrue(values.stream().anyMatch(v -> "temperature".equals(v.getSensorType())));


### PR DESCRIPTION
## Summary
- rename SensorData entity and related repository to SensorReading
- join new sensor_reading table in aggregation queries and services
- rename latest_sensor_health value column to sensor_value and update migrations

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a49966f5cc8328b439aae6c1d23f84