### PR TITLE
Validate aggregated history params and add pagination

### DIFF
--- a/src/test/java/se/hydroleaf/controller/RecordControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/RecordControllerTest.java
@@ -44,7 +44,7 @@ class RecordControllerTest {
                 Instant.parse("2023-01-02T00:00:00Z"),
                 List.of(tempData)
         );
-        when(recordService.aggregatedHistory(eq("dev1"), any(), any(), eq("5m"), isNull()))
+        when(recordService.aggregatedHistory(eq("dev1"), any(), any(), eq("5m"), isNull(), isNull(), isNull(), isNull(), isNull()))
                 .thenReturn(response);
 
         mockMvc.perform(get("/api/records/history/aggregated")


### PR DESCRIPTION
## Summary
- validate `from`, `to`, and `sensorType` on aggregated history endpoint with max 31-day range
- add optional bucket/sensor pagination support in `RecordService.aggregatedHistory`
- update controller and tests for new parameters

## Testing
- `./mvnw -q test` *(failed: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*
- `apt-get update` *(failed: 403  Forbidden [IP: 172.30.0.227 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68a4f35f573883288c45bcd2455eee70