### PR TITLE
Buffer sensor readings and flush to history

### DIFF
--- a/src/main/java/se/hydroleaf/service/SensorValueBuffer.java
+++ b/src/main/java/se/hydroleaf/service/SensorValueBuffer.java
@@ -1,0 +1,97 @@
+package se.hydroleaf.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import se.hydroleaf.model.SensorValueHistory;
+import se.hydroleaf.repository.SensorValueHistoryRepository;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Thread-safe buffer accumulating sensor readings for periodic aggregation.
+ * Entries are keyed by device composite id and sensor type and track the
+ * running sum, count and first timestamp of received values. A scheduled task
+ * flushes the buffer every minute, writing averaged values to
+ * {@code sensor_value_history}.
+ */
+@Service
+public class SensorValueBuffer {
+
+    private record Key(String compositeId, String sensorType) { }
+
+    private static class Accumulator {
+        double sum;
+        long count;
+        Instant firstTimestamp;
+
+        void accumulate(double value, Instant ts) {
+            sum += value;
+            count++;
+            if (firstTimestamp == null || ts.isBefore(firstTimestamp)) {
+                firstTimestamp = ts;
+            }
+        }
+    }
+
+    private final ConcurrentMap<Key, Accumulator> buffer = new ConcurrentHashMap<>();
+    private final SensorValueHistoryRepository sensorValueHistoryRepository;
+
+    public SensorValueBuffer(SensorValueHistoryRepository sensorValueHistoryRepository) {
+        this.sensorValueHistoryRepository = sensorValueHistoryRepository;
+    }
+
+    /**
+     * Add a sensor reading to the buffer.
+     */
+    public void add(String compositeId, String sensorType, double value, Instant timestamp) {
+        Key key = new Key(compositeId, sensorType);
+        buffer.compute(key, (k, acc) -> {
+            if (acc == null) {
+                acc = new Accumulator();
+            }
+            acc.accumulate(value, timestamp);
+            return acc;
+        });
+    }
+
+    /**
+     * Flush the current buffer contents to persistent history. The method is
+     * scheduled to run every minute but can be invoked manually (e.g. from
+     * tests).
+     */
+    @Scheduled(fixedRate = 60000, scheduler = "scheduler")
+    public void flush() {
+        Map<Key, Accumulator> snapshot = drain();
+        if (snapshot.isEmpty()) {
+            return;
+        }
+        List<SensorValueHistory> history = new ArrayList<>(snapshot.size());
+        for (Map.Entry<Key, Accumulator> e : snapshot.entrySet()) {
+            Accumulator a = e.getValue();
+            double avg = a.sum / a.count;
+            history.add(SensorValueHistory.builder()
+                    .compositeId(e.getKey().compositeId())
+                    .sensorType(e.getKey().sensorType())
+                    .sensorValue(avg)
+                    .valueTime(a.firstTimestamp)
+                    .build());
+        }
+        sensorValueHistoryRepository.saveAll(history);
+    }
+
+    private Map<Key, Accumulator> drain() {
+        Map<Key, Accumulator> snapshot = new HashMap<>();
+        buffer.forEach((k, v) -> {
+            if (buffer.remove(k, v)) {
+                snapshot.put(k, v);
+            }
+        });
+        return snapshot;
+    }
+}

--- a/src/test/java/se/hydroleaf/service/RecordServiceDeviceTests.java
+++ b/src/test/java/se/hydroleaf/service/RecordServiceDeviceTests.java
@@ -2,6 +2,7 @@ package se.hydroleaf.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,11 +46,19 @@ class RecordServiceDeviceTests {
 
     @BeforeEach
     void initGroup() {
+        sensorValueBuffer.flush();
+        sensorValueHistoryRepository.deleteAll();
         defaultGroup = deviceGroupRepository.findByMqttTopic("test-group").orElseGet(() -> {
             DeviceGroup g = new DeviceGroup();
             g.setMqttTopic("test-group");
             return deviceGroupRepository.save(g);
         });
+    }
+
+    @AfterEach
+    void clearBuffer() {
+        sensorValueBuffer.flush();
+        sensorValueHistoryRepository.deleteAll();
     }
 
     private Device ensureDevice(String compositeId) {

--- a/src/test/java/se/hydroleaf/service/RecordServiceDeviceTests.java
+++ b/src/test/java/se/hydroleaf/service/RecordServiceDeviceTests.java
@@ -17,6 +17,7 @@ import se.hydroleaf.repository.DeviceRepository;
 import se.hydroleaf.repository.SensorValueHistoryRepository;
 import se.hydroleaf.repository.LatestSensorValueAggregationRepository;
 import se.hydroleaf.repository.LatestSensorValueRepository;
+import se.hydroleaf.service.SensorValueBuffer;
 import se.hydroleaf.model.DeviceType;
 import se.hydroleaf.repository.dto.LiveNowRow;
 
@@ -38,6 +39,7 @@ class RecordServiceDeviceTests {
     @Autowired ActuatorStatusRepository actuatorStatusRepository;
     @Autowired LatestSensorValueRepository latestSensorValueRepository;
     @Autowired LatestSensorValueAggregationRepository latestAggregationRepository;
+    @Autowired SensorValueBuffer sensorValueBuffer;
 
     private DeviceGroup defaultGroup;
 
@@ -89,6 +91,9 @@ class RecordServiceDeviceTests {
         long pumpBefore = actuatorStatusRepository.count();
         recordService.saveRecord(compositeId, node);
 
+        // buffer should delay persistence until flush
+        assertEquals(0, sensorValueHistoryRepository.count());
+
         Device saved = deviceRepository.findById(compositeId).orElseThrow();
         assertEquals("S02", saved.getSystem());
         assertEquals("L02", saved.getLayer());
@@ -102,6 +107,7 @@ class RecordServiceDeviceTests {
         assertNotNull(lightAvg.getAvgValue());
         assertTrue(lightAvg.getDeviceCount() >= 1);
 
+        sensorValueBuffer.flush();
         assertTrue(sensorValueHistoryRepository.findAll().stream()
                 .anyMatch(d -> "ph".equals(d.getSensorType())));
 
@@ -112,6 +118,31 @@ class RecordServiceDeviceTests {
                 .orElseThrow();
         assertFalse(pumpRow.getState());
         assertEquals(Instant.parse("2025-01-01T00:00:00Z"), pumpRow.getTimestamp());
+    }
+
+    @Test
+    void buffered_readings_are_averaged_on_flush() throws Exception {
+        final String compositeId = "S10-L10-AVG";
+        ensureDevice(compositeId);
+
+        String first = """
+                {"timestamp":"2025-01-01T00:00:00Z","sensors":[{"sensorType":"ph","value":6.0}]}
+                """;
+        String second = """
+                {"timestamp":"2025-01-01T00:00:30Z","sensors":[{"sensorType":"ph","value":8.0}]}
+                """;
+        recordService.saveRecord(compositeId, objectMapper.readTree(first));
+        recordService.saveRecord(compositeId, objectMapper.readTree(second));
+
+        // nothing persisted until flush
+        assertEquals(0, sensorValueHistoryRepository.count());
+
+        sensorValueBuffer.flush();
+
+        var all = sensorValueHistoryRepository.findAll();
+        assertEquals(1, all.size());
+        assertEquals(7.0, all.get(0).getSensorValue());
+        assertEquals(Instant.parse("2025-01-01T00:00:00Z"), all.get(0).getValueTime());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- introduce `SensorValueBuffer` to accumulate sensor readings and flush averages every minute
- update `RecordService` to buffer readings and immediately upsert `LatestSensorValue`
- add tests ensuring buffered readings persist only after flush and are averaged

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5545be5948328b0f70c28458a4a7a