### PR TITLE
Add generated system and layer columns with index

### DIFF
--- a/src/main/java/se/hydroleaf/model/SensorValueHistory.java
+++ b/src/main/java/se/hydroleaf/model/SensorValueHistory.java
@@ -9,7 +9,8 @@ import java.time.Instant;
 @Table(name = "sensor_value_history",
        indexes = {
            @Index(name = "idx_svh_device_sensor_time", columnList = "composite_id, sensor_type, value_time DESC"),
-           @Index(name = "idx_svh_device_time", columnList = "composite_id, value_time")
+           @Index(name = "idx_svh_device_time", columnList = "composite_id, value_time"),
+           @Index(name = "idx_svh_system_layer", columnList = "system_part, layer_part")
        })
 @IdClass(SensorValueHistoryId.class)
 @Getter
@@ -35,4 +36,10 @@ public class SensorValueHistory {
 
     @Column(name = "sensor_value")
     private Double sensorValue;
+
+    @Column(name = "system_part", length = 64, insertable = false, updatable = false)
+    private String systemPart;
+
+    @Column(name = "layer_part", length = 64, insertable = false, updatable = false)
+    private String layerPart;
 }

--- a/src/main/resources/migrations/V2__add_system_layer_columns.sql
+++ b/src/main/resources/migrations/V2__add_system_layer_columns.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS idx_svh_system_layer;
+
+ALTER TABLE sensor_value_history
+    ADD COLUMN IF NOT EXISTS system_part VARCHAR(64) GENERATED ALWAYS AS (split_part(composite_id, '-', 1)) STORED;
+
+ALTER TABLE sensor_value_history
+    ADD COLUMN IF NOT EXISTS layer_part VARCHAR(64) GENERATED ALWAYS AS (split_part(composite_id, '-', 2)) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_svh_system_layer
+    ON sensor_value_history(system_part, layer_part);


### PR DESCRIPTION
## Summary
- add Flyway migration to split composite_id into generated system and layer columns and index them
- map generated columns in SensorValueHistory entity

## Testing
- `mvn -q test` *(fails: Could not transfer artifact spring-boot-starter-parent: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a55423f9f08328b25b1876030fc4c3