### PR TITLE
refactor: streamline LiveNowRow DTO

### DIFF
--- a/src/main/java/se/hydroleaf/repository/dto/LiveNowRow.java
+++ b/src/main/java/se/hydroleaf/repository/dto/LiveNowRow.java
@@ -1,7 +1,5 @@
 package se.hydroleaf.repository.dto;
 
-import lombok.Builder;
-
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -15,11 +13,6 @@ public record LiveNowRow(
         Number deviceCount,
         Object recordTime
 ) {
-    public String getSystem() { return system; }
-    public String getLayer() { return layer; }
-    public String getSensorType() { return sensorType; }
-    public String getUnit() { return unit; }
-
     public Double getAvgValue() { return avgValue != null ? avgValue.doubleValue() : null; }
 
     public Long getDeviceCount() { return deviceCount != null ? deviceCount.longValue() : null; }

--- a/src/test/java/se/hydroleaf/service/RecordServiceDeviceTests.java
+++ b/src/test/java/se/hydroleaf/service/RecordServiceDeviceTests.java
@@ -110,7 +110,7 @@ class RecordServiceDeviceTests {
 
         List<LiveNowRow> rows = latestAggregationRepository.fetchLatestSensorAverages(List.of(DeviceType.LIGHT.getName()));
         LiveNowRow lightAvg = rows.stream()
-                .filter(r -> "S02".equals(r.getSystem()) && "L02".equals(r.getLayer()))
+                .filter(r -> "S02".equals(r.system()) && "L02".equals(r.layer()))
                 .findFirst().orElse(null);
         assertNotNull(lightAvg);
         assertNotNull(lightAvg.getAvgValue());


### PR DESCRIPTION
## Summary
- drop unused Lombok import and redundant getters from `LiveNowRow`
- use record accessors throughout `StatusService` and tests

## Testing
- `mvn -q -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a616d19e8c8328bafdcaa40a1a246d