### PR TITLE
Add endpoint to list devices

### DIFF
--- a/src/main/java/se/hydroleaf/controller/DeviceController.java
+++ b/src/main/java/se/hydroleaf/controller/DeviceController.java
@@ -1,0 +1,25 @@
+package se.hydroleaf.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import se.hydroleaf.repository.dto.DeviceResponse;
+import se.hydroleaf.service.DeviceService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/devices")
+public class DeviceController {
+
+    private final DeviceService deviceService;
+
+    public DeviceController(DeviceService deviceService) {
+        this.deviceService = deviceService;
+    }
+
+    @GetMapping
+    public List<DeviceResponse> getAllDevices() {
+        return deviceService.getAllDevices();
+    }
+}

--- a/src/main/java/se/hydroleaf/repository/dto/DeviceResponse.java
+++ b/src/main/java/se/hydroleaf/repository/dto/DeviceResponse.java
@@ -1,0 +1,3 @@
+package se.hydroleaf.repository.dto;
+
+public record DeviceResponse(String compositeId, String system, String layer, String deviceId) {}

--- a/src/main/java/se/hydroleaf/service/DeviceService.java
+++ b/src/main/java/se/hydroleaf/service/DeviceService.java
@@ -1,0 +1,23 @@
+package se.hydroleaf.service;
+
+import org.springframework.stereotype.Service;
+import se.hydroleaf.repository.DeviceRepository;
+import se.hydroleaf.repository.dto.DeviceResponse;
+
+import java.util.List;
+
+@Service
+public class DeviceService {
+
+    private final DeviceRepository deviceRepository;
+
+    public DeviceService(DeviceRepository deviceRepository) {
+        this.deviceRepository = deviceRepository;
+    }
+
+    public List<DeviceResponse> getAllDevices() {
+        return deviceRepository.findAll().stream()
+                .map(d -> new DeviceResponse(d.getCompositeId(), d.getSystem(), d.getLayer(), d.getDeviceId()))
+                .toList();
+    }
+}


### PR DESCRIPTION
## Summary
- expose `/api/devices` to list all devices without group information
- add service and DTO to map device entities to response

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a78c5afce08328b540127c0fdd6bdc