### PR TITLE
feat: support multiple sensor types

### DIFF
--- a/src/main/java/se/hydroleaf/controller/RecordController.java
+++ b/src/main/java/se/hydroleaf/controller/RecordController.java
@@ -13,6 +13,7 @@ import se.hydroleaf.service.RecordService;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.regex.Pattern;
 
 @RestController
@@ -35,7 +36,7 @@ public class RecordController {
             @RequestParam("from") String from,
             @RequestParam("to") String to,
             @RequestParam(name = "bucket", defaultValue = "5m") String bucket,
-            @RequestParam(name = "sensorType", required = false) String sensorType,
+            @RequestParam(name = "sensorType", required = false) List<String> sensorTypes,
             @RequestParam(name = "bucketLimit", required = false) Integer bucketLimit,
             @RequestParam(name = "bucketOffset", required = false) Integer bucketOffset,
             @RequestParam(name = "sensorLimit", required = false) Integer sensorLimit,
@@ -52,12 +53,16 @@ public class RecordController {
         if (Duration.between(fromInst, toInst).toDays() > MAX_RANGE_DAYS) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Range exceeds " + MAX_RANGE_DAYS + " days");
         }
-        if (sensorType != null && !SENSOR_TYPE_PATTERN.matcher(sensorType).matches()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid sensorType");
+        if (sensorTypes != null) {
+            for (String st : sensorTypes) {
+                if (!SENSOR_TYPE_PATTERN.matcher(st).matches()) {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid sensorType");
+                }
+            }
         }
         try {
             return recordService.aggregatedHistory(
-                    compositeId, fromInst, toInst, bucket, sensorType,
+                    compositeId, fromInst, toInst, bucket, sensorTypes,
                     bucketLimit, bucketOffset, sensorLimit, sensorOffset);
         } catch (IllegalArgumentException iae) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, iae.getMessage(), iae);


### PR DESCRIPTION
## Summary
- allow aggregated history endpoint to accept multiple sensor types
- support aggregating multiple sensor types in RecordService
- add tests for multi-sensor aggregation

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for se.hydroleaf:demo:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8eebd15a883289fbd8b2b5a741ce4