### PR TITLE
Expose device composite ID lookup

### DIFF
--- a/src/main/java/se/hydroleaf/controller/DeviceController.java
+++ b/src/main/java/se/hydroleaf/controller/DeviceController.java
@@ -27,6 +27,13 @@ public class DeviceController {
         return deviceService.getAllDevices();
     }
 
+    @GetMapping("/composite-ids")
+    public List<String> getCompositeIds(@RequestParam String system,
+                                        @RequestParam String layer,
+                                        @RequestParam(required = false) String deviceId) {
+        return deviceService.getCompositeIds(system, layer, deviceId);
+    }
+
     @GetMapping("/all")
     public DeviceSensorsResponse getAllDevicesWithSensors() {
         return deviceService.getAllDevicesWithSensors();

--- a/src/main/java/se/hydroleaf/service/DeviceService.java
+++ b/src/main/java/se/hydroleaf/service/DeviceService.java
@@ -32,6 +32,18 @@ public class DeviceService {
                 .toList();
     }
 
+    public List<String> getCompositeIds(String system, String layer, String deviceId) {
+        List<Device> devices = deviceRepository.findBySystemAndLayer(system, layer);
+        if (deviceId != null && !deviceId.isBlank()) {
+            devices = devices.stream()
+                    .filter(d -> d.getDeviceId().equals(deviceId))
+                    .toList();
+        }
+        return devices.stream()
+                .map(Device::getCompositeId)
+                .toList();
+    }
+
     public DeviceSensorsResponse getSensorsForDevices(List<String> compositeIds) {
         List<Device> devices = deviceRepository.findAllById(compositeIds);
         Set<String> found = devices.stream().map(Device::getCompositeId).collect(Collectors.toSet());

--- a/src/test/java/se/hydroleaf/controller/DeviceControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/DeviceControllerTest.java
@@ -65,4 +65,17 @@ class DeviceControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.devices[0].deviceId").value("G01"));
     }
+
+    @Test
+    void getCompositeIdsReturnsIds() throws Exception {
+        when(deviceService.getCompositeIds("S01", "L01", "D01"))
+                .thenReturn(List.of("S01-L01-D01"));
+
+        mockMvc.perform(get("/api/devices/composite-ids")
+                        .param("system", "S01")
+                        .param("layer", "L01")
+                        .param("deviceId", "D01"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").value("S01-L01-D01"));
+    }
 }

--- a/src/test/java/se/hydroleaf/service/DeviceServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/DeviceServiceTest.java
@@ -1,0 +1,48 @@
+package se.hydroleaf.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.hydroleaf.model.Device;
+import se.hydroleaf.repository.DeviceRepository;
+import se.hydroleaf.repository.LatestSensorValueRepository;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceServiceTest {
+
+    @Mock
+    DeviceRepository deviceRepository;
+
+    @Mock
+    LatestSensorValueRepository latestSensorValueRepository;
+
+    private DeviceService deviceService;
+
+    @BeforeEach
+    void setup() {
+        deviceService = new DeviceService(deviceRepository, latestSensorValueRepository);
+    }
+
+    @Test
+    void getCompositeIdsFiltersByDeviceIdWhenProvided() {
+        Device d1 = new Device();
+        d1.setCompositeId("S01-L01-A1");
+        d1.setDeviceId("A1");
+        Device d2 = new Device();
+        d2.setCompositeId("S01-L01-B1");
+        d2.setDeviceId("B1");
+        when(deviceRepository.findBySystemAndLayer("S01", "L01"))
+                .thenReturn(List.of(d1, d2));
+
+        List<String> result = deviceService.getCompositeIds("S01", "L01", "B1");
+
+        assertEquals(List.of("S01-L01-B1"), result);
+    }
+}


### PR DESCRIPTION
## Summary
- add service method to collect device composite IDs by system, layer, and optional device id
- expose new `/api/devices/composite-ids` endpoint
- test composite ID lookup filtering

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ff6b6d2c8328b326ae67d99a6d62