### PR TITLE
Improve DB connection pool monitoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>spring-boot-starter-websocket</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
             <version>1.2.5</version>

--- a/src/main/java/se/hydroleaf/config/ConnectionPoolMetrics.java
+++ b/src/main/java/se/hydroleaf/config/ConnectionPoolMetrics.java
@@ -1,0 +1,43 @@
+package se.hydroleaf.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.pool.HikariPoolMXBean;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+
+/**
+ * Periodically logs HikariCP pool metrics so that active/idle connection
+ * imbalances can be detected early. A warning is emitted when the pool is
+ * exhausted.
+ */
+@Slf4j
+@Component
+public class ConnectionPoolMetrics {
+
+    private final HikariDataSource dataSource;
+
+    public ConnectionPoolMetrics(DataSource dataSource) {
+        this.dataSource = dataSource instanceof HikariDataSource
+                ? (HikariDataSource) dataSource
+                : null;
+    }
+
+    @Scheduled(fixedDelayString = "${metrics.connection-pool.log-interval:60000}")
+    public void logMetrics() {
+        if (dataSource == null) {
+            return; // DataSource not HikariCP; nothing to log
+        }
+        HikariPoolMXBean mxBean = dataSource.getHikariPoolMXBean();
+        int active = mxBean.getActiveConnections();
+        int idle = mxBean.getIdleConnections();
+        int total = mxBean.getTotalConnections();
+        int awaiting = mxBean.getThreadsAwaitingConnection();
+        log.info("HikariCP - active:{} idle:{} total:{} awaiting:{}", active, idle, total, awaiting);
+        if (active >= dataSource.getMaximumPoolSize()) {
+            log.warn("HikariCP pool exhausted: {} active connections", active);
+        }
+    }
+}

--- a/src/main/java/se/hydroleaf/config/ConnectionPoolMetrics.java
+++ b/src/main/java/se/hydroleaf/config/ConnectionPoolMetrics.java
@@ -1,7 +1,7 @@
 package se.hydroleaf.config;
 
 import com.zaxxer.hikari.HikariDataSource;
-import com.zaxxer.hikari.pool.HikariPoolMXBean;
+import com.zaxxer.hikari.HikariPoolMXBean;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 20
+      connection-timeout: 30000
   jpa:
     hibernate:
       ddl-auto: update
@@ -39,10 +42,14 @@ server:
     key-store-password: ${SSL_KEY_STORE_PASSWORD:}
     key-store-type: ${SSL_KEY_STORE_TYPE:PKCS12}
     key-alias: ${SSL_KEY_ALIAS:}
-
 logging:
   level:
     se:
       hydroleaf:
         scheduler: DEBUG
         mqtt: DEBUG
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus


### PR DESCRIPTION
## Summary
- add Spring Boot actuator for metrics
- configure HikariCP pool size and timeout
- log HikariCP active vs idle connections to spot leaks

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adf62953bc83289f8298b035e33c7a