### PR TITLE
Improve WebSocket resilience and diagnostics

### DIFF
--- a/src/main/java/se/hydroleaf/websocket/LiveFeedWebSocketController.java
+++ b/src/main/java/se/hydroleaf/websocket/LiveFeedWebSocketController.java
@@ -1,0 +1,50 @@
+package se.hydroleaf.websocket;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+import se.hydroleaf.repository.dto.snapshot.LiveNowSnapshot;
+import se.hydroleaf.service.StatusService;
+
+/**
+ * Handles WebSocket requests for live feed data.
+ */
+@Slf4j
+@Controller
+public class LiveFeedWebSocketController {
+
+    private final StatusService statusService;
+    private final ObjectMapper objectMapper;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final WebSocketSessionTracker sessionTracker;
+
+    public LiveFeedWebSocketController(StatusService statusService,
+                                       ObjectMapper objectMapper,
+                                       SimpMessagingTemplate messagingTemplate,
+                                       WebSocketSessionTracker sessionTracker) {
+        this.statusService = statusService;
+        this.objectMapper = objectMapper;
+        this.messagingTemplate = messagingTemplate;
+        this.sessionTracker = sessionTracker;
+    }
+
+    @MessageMapping("/live-now")
+    public void liveNow() {
+        try {
+            LiveNowSnapshot snapshot = statusService.getLiveNowSnapshot();
+            String payload = objectMapper.writeValueAsString(snapshot);
+            messagingTemplate.convertAndSend("/topic/live_now", payload);
+        } catch (DataAccessException dae) {
+            log.warn("DB access failed for live feed request (sessions: {})", sessionTracker.getSessionCount(), dae);
+            messagingTemplate.convertAndSend("/topic/live_now", "{\"error\":\"data unavailable\"}");
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize LiveNowSnapshot", e);
+        } catch (Exception e) {
+            log.warn("liveNow message handling failed", e);
+        }
+    }
+}

--- a/src/main/java/se/hydroleaf/websocket/WebSocketSessionListener.java
+++ b/src/main/java/se/hydroleaf/websocket/WebSocketSessionListener.java
@@ -1,0 +1,33 @@
+package se.hydroleaf.websocket;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+/**
+ * Listens for WebSocket connect and disconnect events to maintain session counts.
+ */
+@Slf4j
+@Component
+public class WebSocketSessionListener {
+
+    private final WebSocketSessionTracker tracker;
+
+    public WebSocketSessionListener(WebSocketSessionTracker tracker) {
+        this.tracker = tracker;
+    }
+
+    @EventListener
+    public void handleSessionConnected(SessionConnectEvent event) {
+        int count = tracker.increment();
+        log.info("WebSocket session connected. Active sessions: {}", count);
+    }
+
+    @EventListener
+    public void handleSessionDisconnect(SessionDisconnectEvent event) {
+        int count = tracker.decrement();
+        log.info("WebSocket session disconnected. Active sessions: {}", count);
+    }
+}

--- a/src/main/java/se/hydroleaf/websocket/WebSocketSessionTracker.java
+++ b/src/main/java/se/hydroleaf/websocket/WebSocketSessionTracker.java
@@ -1,0 +1,25 @@
+package se.hydroleaf.websocket;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.stereotype.Component;
+
+/**
+ * Tracks active WebSocket sessions for monitoring purposes.
+ */
+@Component
+public class WebSocketSessionTracker {
+
+    private final AtomicInteger sessions = new AtomicInteger();
+
+    public int increment() {
+        return sessions.incrementAndGet();
+    }
+
+    public int decrement() {
+        return sessions.decrementAndGet();
+    }
+
+    public int getSessionCount() {
+        return sessions.get();
+    }
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -7,5 +7,31 @@
 <body>
   <h1>HydroLeaf Application</h1>
   <p>This is a placeholder page served by the backend.</p>
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+  <script>
+    let stompClient = null;
+    let reconnectAttempts = 0;
+
+    function connect() {
+      const socket = new SockJS('/ws');
+      stompClient = Stomp.over(socket);
+      stompClient.connect({}, () => {
+        reconnectAttempts = 0;
+        console.log('Connected');
+      }, () => {
+        scheduleReconnect();
+      });
+    }
+
+    function scheduleReconnect() {
+      reconnectAttempts++;
+      const delay = Math.min(30000, 1000 * Math.pow(2, reconnectAttempts));
+      console.log('Reconnecting in ' + delay + 'ms');
+      setTimeout(connect, delay);
+    }
+
+    connect();
+  </script>
 </body>
 </html>

--- a/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
+++ b/src/test/java/se/hydroleaf/scheduler/LiveFeedSchedulerTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import se.hydroleaf.mqtt.TopicPublisher;
+import se.hydroleaf.websocket.WebSocketSessionTracker;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -85,7 +86,8 @@ class LiveFeedSchedulerTest {
                 .registerModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         TopicPublisher topicPublisher = new TopicPublisher(true, messagingTemplate);
-        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, mapper);
+        WebSocketSessionTracker tracker = new WebSocketSessionTracker();
+        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, mapper, tracker);
         scheduler.sendLiveNow();
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
@@ -113,7 +115,8 @@ class LiveFeedSchedulerTest {
                 .thenReturn("{}");
 
         TopicPublisher topicPublisher = new TopicPublisher(true, messagingTemplate);
-        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, mapper);
+        WebSocketSessionTracker tracker = new WebSocketSessionTracker();
+        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, mapper, tracker);
 
         assertDoesNotThrow(scheduler::sendLiveNow);
         scheduler.sendLiveNow();
@@ -131,7 +134,8 @@ class LiveFeedSchedulerTest {
 
         ObjectMapper mapper = new ObjectMapper();
         TopicPublisher topicPublisher = new TopicPublisher(true, messagingTemplate);
-        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, mapper);
+        WebSocketSessionTracker tracker = new WebSocketSessionTracker();
+        LiveFeedScheduler scheduler = new LiveFeedScheduler(statusService, topicPublisher, mapper, tracker);
 
         ExecutorService exec = Executors.newFixedThreadPool(10);
         for (int i = 0; i < 10; i++) {


### PR DESCRIPTION
## Summary
- Send fallback messages when live data cannot be fetched and log active WebSocket sessions
- Handle DB failures in WebSocket controller with fallback payload
- Add client-side WebSocket reconnection with exponential backoff

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adf6a43828832891612215a4cc1b54