### PR TITLE
Add generated system and layer columns to SensorValueHistory

### DIFF
--- a/src/main/java/se/hydroleaf/model/SensorValueHistory.java
+++ b/src/main/java/se/hydroleaf/model/SensorValueHistory.java
@@ -1,11 +1,6 @@
 package se.hydroleaf.model;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.IdClass;
-import jakarta.persistence.Index;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -53,13 +48,24 @@ public class SensorValueHistory {
 
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
-    @Column(name = "system_part", insertable = false, updatable = false,
-            columnDefinition = "VARCHAR(64) GENERATED ALWAYS AS (split_part(composite_id, '-', 1)) STORED")
+    @Column(name = "system_part", length = 64)
     private String systemPart;
 
     @EqualsAndHashCode.Exclude
     @ToString.Exclude
-    @Column(name = "layer_part", insertable = false, updatable = false,
-            columnDefinition = "VARCHAR(64) GENERATED ALWAYS AS (split_part(composite_id, '-', 2)) STORED")
+    @Column(name = "layer_part", length = 64)
     private String layerPart;
+
+    @PrePersist
+    @PreUpdate
+    private void fillParts() {
+        if (compositeId != null) {
+            String[] parts = compositeId.split("-", 3);
+            systemPart = parts.length > 0 ? parts[0] : null;
+            layerPart = parts.length > 1 ? parts[1] : null;
+        } else {
+            systemPart = null;
+            layerPart = null;
+        }
+    }
 }

--- a/src/main/java/se/hydroleaf/model/SensorValueHistory.java
+++ b/src/main/java/se/hydroleaf/model/SensorValueHistory.java
@@ -50,4 +50,16 @@ public class SensorValueHistory {
 
     @Column(name = "sensor_value")
     private Double sensorValue;
+
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @Column(name = "system_part", insertable = false, updatable = false,
+            columnDefinition = "VARCHAR(64) GENERATED ALWAYS AS (split_part(composite_id, '-', 1)) STORED")
+    private String systemPart;
+
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @Column(name = "layer_part", insertable = false, updatable = false,
+            columnDefinition = "VARCHAR(64) GENERATED ALWAYS AS (split_part(composite_id, '-', 2)) STORED")
+    private String layerPart;
 }


### PR DESCRIPTION
## Summary
- add generated `system_part` and `layer_part` columns to `SensorValueHistory`
- exclude generated columns from persistence updates and hashing

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0270b04c8328b4acdc65041a7373