### PR TITLE
Add notes API

### DIFF
--- a/src/main/java/se/hydroleaf/controller/NoteController.java
+++ b/src/main/java/se/hydroleaf/controller/NoteController.java
@@ -1,0 +1,39 @@
+package se.hydroleaf.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import se.hydroleaf.model.Note;
+import se.hydroleaf.service.NoteService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notes")
+@RequiredArgsConstructor
+public class NoteController {
+
+    private final NoteService noteService;
+
+    @GetMapping
+    public List<Note> getNotes() {
+        return noteService.getAllNotes();
+    }
+
+    @GetMapping("/search")
+    public List<Note> searchNotes(@RequestParam String query) {
+        return noteService.searchByContent(query);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Note createNote(@RequestBody Note note) {
+        return noteService.save(note);
+    }
+}

--- a/src/main/java/se/hydroleaf/model/Note.java
+++ b/src/main/java/se/hydroleaf/model/Note.java
@@ -1,0 +1,39 @@
+package se.hydroleaf.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "note")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Note {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime date;
+
+    @Column(nullable = false)
+    private String content;
+}

--- a/src/main/java/se/hydroleaf/repository/NoteRepository.java
+++ b/src/main/java/se/hydroleaf/repository/NoteRepository.java
@@ -1,0 +1,10 @@
+package se.hydroleaf.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import se.hydroleaf.model.Note;
+import java.util.List;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {
+
+    List<Note> findByContentContainingIgnoreCase(String query);
+}

--- a/src/main/java/se/hydroleaf/service/NoteService.java
+++ b/src/main/java/se/hydroleaf/service/NoteService.java
@@ -1,0 +1,27 @@
+package se.hydroleaf.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import se.hydroleaf.model.Note;
+import se.hydroleaf.repository.NoteRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NoteService {
+
+    private final NoteRepository noteRepository;
+
+    public List<Note> getAllNotes() {
+        return noteRepository.findAll();
+    }
+
+    public Note save(Note note) {
+        return noteRepository.save(note);
+    }
+
+    public List<Note> searchByContent(String query) {
+        return noteRepository.findByContentContainingIgnoreCase(query);
+    }
+}

--- a/src/test/java/se/hydroleaf/controller/NoteControllerTest.java
+++ b/src/test/java/se/hydroleaf/controller/NoteControllerTest.java
@@ -1,0 +1,85 @@
+package se.hydroleaf.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import se.hydroleaf.model.Note;
+import se.hydroleaf.repository.NoteRepository;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class NoteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private NoteRepository noteRepository;
+
+    @Test
+    void getNotesReturnsStoredNotes() throws Exception {
+        noteRepository.save(Note.builder()
+                .title("test title")
+                .date(LocalDateTime.parse("2023-01-01T10:15:30"))
+                .content("test note")
+                .build());
+
+        mockMvc.perform(get("/api/notes"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].title").value("test title"))
+                .andExpect(jsonPath("$[0].date").value("2023-01-01T10:15:30"))
+                .andExpect(jsonPath("$[0].content").value("test note"));
+    }
+
+    @Test
+    void postCreatesNote() throws Exception {
+        String payload = "{\"title\":\"new note\",\"date\":\"2023-02-02T15:30:00\",\"content\":\"new content\"}";
+
+        mockMvc.perform(post("/api/notes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.title").value("new note"))
+                .andExpect(jsonPath("$.date").value("2023-02-02T15:30:00"))
+                .andExpect(jsonPath("$.content").value("new content"));
+
+        assertThat(noteRepository.findAll())
+                .extracting(Note::getTitle, Note::getDate, Note::getContent)
+                .containsExactly(tuple("new note", LocalDateTime.parse("2023-02-02T15:30:00"), "new content"));
+    }
+
+    @Test
+    void searchReturnsNotesContainingQuery() throws Exception {
+        noteRepository.save(Note.builder()
+                .title("first")
+                .date(LocalDateTime.parse("2023-03-03T12:00:00"))
+                .content("some apple text")
+                .build());
+        noteRepository.save(Note.builder()
+                .title("second")
+                .date(LocalDateTime.parse("2023-04-04T12:00:00"))
+                .content("banana content")
+                .build());
+
+        mockMvc.perform(get("/api/notes/search")
+                        .param("query", "apple"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].content").value("some apple text"))
+                .andExpect(jsonPath("$", org.hamcrest.Matchers.hasSize(1)));
+    }
+}


### PR DESCRIPTION
## Summary
- create Note entity and repository for storing notes
- add Note service and controller with endpoints to create, list, and search notes
- test note retrieval, creation, and search endpoints
- extend Note with title and date fields

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b839808eec832895353f41d8c09988