### PR TITLE
feat: add sensor config CRUD endpoints

### DIFF
--- a/src/main/java/se/hydroleaf/controller/SensorConfigController.java
+++ b/src/main/java/se/hydroleaf/controller/SensorConfigController.java
@@ -1,0 +1,69 @@
+package se.hydroleaf.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import se.hydroleaf.model.SensorConfig;
+import se.hydroleaf.service.SensorConfigService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/sensor-config")
+public class SensorConfigController {
+
+    private final SensorConfigService service;
+
+    public SensorConfigController(SensorConfigService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public List<SensorConfig> getAll() {
+        return service.getAll();
+    }
+
+    @GetMapping("/{sensorType}")
+    public SensorConfig get(@PathVariable String sensorType) {
+        try {
+            return service.get(sensorType);
+        } catch (IllegalArgumentException iae) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, iae.getMessage(), iae);
+        }
+    }
+
+    @PostMapping
+    public SensorConfig create(@RequestBody SensorConfig config) {
+        try {
+            return service.create(config);
+        } catch (IllegalArgumentException iae) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, iae.getMessage(), iae);
+        }
+    }
+
+    @PutMapping("/{sensorType}")
+    public SensorConfig update(@PathVariable String sensorType, @RequestBody SensorConfig config) {
+        try {
+            return service.update(sensorType, config);
+        } catch (IllegalArgumentException iae) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, iae.getMessage(), iae);
+        }
+    }
+
+    @DeleteMapping("/{sensorType}")
+    public void delete(@PathVariable String sensorType) {
+        try {
+            service.delete(sensorType);
+        } catch (IllegalArgumentException iae) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, iae.getMessage(), iae);
+        }
+    }
+}
+

--- a/src/main/java/se/hydroleaf/model/SensorConfig.java
+++ b/src/main/java/se/hydroleaf/model/SensorConfig.java
@@ -1,0 +1,57 @@
+package se.hydroleaf.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * JPA entity representing ideal configuration for a sensor type.
+ */
+@Entity
+@Table(
+        name = "sensor_config",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "ux_sensor_config_sensor_type",
+                        columnNames = {"sensor_type"}
+                )
+        }
+)
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SensorConfig {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "sensor_type", length = 64, nullable = false)
+    private String sensorType;
+
+    @Column(name = "min_value", nullable = false)
+    private Double minValue;
+
+    @Column(name = "max_value", nullable = false)
+    private Double maxValue;
+
+    @Column(name = "description", length = 512)
+    private String description;
+}
+

--- a/src/main/java/se/hydroleaf/repository/SensorConfigRepository.java
+++ b/src/main/java/se/hydroleaf/repository/SensorConfigRepository.java
@@ -1,0 +1,17 @@
+package se.hydroleaf.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import se.hydroleaf.model.SensorConfig;
+
+public interface SensorConfigRepository extends JpaRepository<SensorConfig, Long> {
+
+    Optional<SensorConfig> findBySensorType(String sensorType);
+
+    boolean existsBySensorType(String sensorType);
+
+    void deleteBySensorType(String sensorType);
+}
+

--- a/src/main/java/se/hydroleaf/service/SensorConfigService.java
+++ b/src/main/java/se/hydroleaf/service/SensorConfigService.java
@@ -1,0 +1,49 @@
+package se.hydroleaf.service;
+
+import org.springframework.stereotype.Service;
+import se.hydroleaf.model.SensorConfig;
+import se.hydroleaf.repository.SensorConfigRepository;
+
+import java.util.List;
+
+@Service
+public class SensorConfigService {
+
+    private final SensorConfigRepository repository;
+
+    public SensorConfigService(SensorConfigRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<SensorConfig> getAll() {
+        return repository.findAll();
+    }
+
+    public SensorConfig get(String sensorType) {
+        return repository.findBySensorType(sensorType)
+                .orElseThrow(() -> new IllegalArgumentException("Unknown sensor type: " + sensorType));
+    }
+
+    public SensorConfig create(SensorConfig config) {
+        if (repository.existsBySensorType(config.getSensorType())) {
+            throw new IllegalArgumentException("Sensor type already exists: " + config.getSensorType());
+        }
+        return repository.save(config);
+    }
+
+    public SensorConfig update(String sensorType, SensorConfig config) {
+        SensorConfig existing = get(sensorType);
+        existing.setMinValue(config.getMinValue());
+        existing.setMaxValue(config.getMaxValue());
+        existing.setDescription(config.getDescription());
+        return repository.save(existing);
+    }
+
+    public void delete(String sensorType) {
+        if (!repository.existsBySensorType(sensorType)) {
+            throw new IllegalArgumentException("Unknown sensor type: " + sensorType);
+        }
+        repository.deleteBySensorType(sensorType);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `SensorConfig` entity for ideal sensor ranges
- expose CRUD service and REST controller for managing sensor configurations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for se.hydroleaf:demo:0.0.1-SNAPSHOT: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b83d8efd488328a52435854c3343b4