### PR TITLE
Add validation for sensor configuration inputs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-websocket</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/se/hydroleaf/controller/SensorConfigController.java
+++ b/src/main/java/se/hydroleaf/controller/SensorConfigController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+import jakarta.validation.Valid;
 import se.hydroleaf.model.SensorConfig;
 import se.hydroleaf.service.SensorConfigService;
 
@@ -40,7 +41,7 @@ public class SensorConfigController {
     }
 
     @PostMapping
-    public SensorConfig create(@RequestBody SensorConfig config) {
+    public SensorConfig create(@Valid @RequestBody SensorConfig config) {
         try {
             return service.create(config);
         } catch (IllegalArgumentException iae) {
@@ -49,7 +50,7 @@ public class SensorConfigController {
     }
 
     @PutMapping("/{sensorType}")
-    public SensorConfig update(@PathVariable String sensorType, @RequestBody SensorConfig config) {
+    public SensorConfig update(@PathVariable String sensorType, @Valid @RequestBody SensorConfig config) {
         try {
             return service.update(sensorType, config);
         } catch (IllegalArgumentException iae) {

--- a/src/main/java/se/hydroleaf/model/SensorConfig.java
+++ b/src/main/java/se/hydroleaf/model/SensorConfig.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotNull;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -45,9 +46,11 @@ public class SensorConfig {
     @Column(name = "sensor_type", length = 64, nullable = false)
     private String sensorType;
 
+    @NotNull
     @Column(name = "min_value", nullable = false)
     private Double minValue;
 
+    @NotNull
     @Column(name = "max_value", nullable = false)
     private Double maxValue;
 

--- a/src/main/java/se/hydroleaf/service/SensorConfigService.java
+++ b/src/main/java/se/hydroleaf/service/SensorConfigService.java
@@ -5,6 +5,7 @@ import se.hydroleaf.model.SensorConfig;
 import se.hydroleaf.repository.SensorConfigRepository;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 public class SensorConfigService {
@@ -25,6 +26,9 @@ public class SensorConfigService {
     }
 
     public SensorConfig create(SensorConfig config) {
+        if (config.getMinValue() == null || config.getMaxValue() == null) {
+            throw new IllegalArgumentException("Min and max values must be provided");
+        }
         if (repository.existsBySensorType(config.getSensorType())) {
             throw new IllegalArgumentException("Sensor type already exists: " + config.getSensorType());
         }
@@ -33,8 +37,8 @@ public class SensorConfigService {
 
     public SensorConfig update(String sensorType, SensorConfig config) {
         SensorConfig existing = get(sensorType);
-        existing.setMinValue(config.getMinValue());
-        existing.setMaxValue(config.getMaxValue());
+        existing.setMinValue(Objects.requireNonNull(config.getMinValue(), "Min value must be provided"));
+        existing.setMaxValue(Objects.requireNonNull(config.getMaxValue(), "Max value must be provided"));
         existing.setDescription(config.getDescription());
         return repository.save(existing);
     }


### PR DESCRIPTION
## Summary
- enforce non-null min and max values for sensor configurations
- validate request bodies and add Spring validation dependency
- handle missing values in service layer

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b894f0e680832889384cdcf29eede2