### PR TITLE
Allow sensor config creation by type

### DIFF
--- a/src/main/java/se/hydroleaf/controller/SensorConfigController.java
+++ b/src/main/java/se/hydroleaf/controller/SensorConfigController.java
@@ -49,6 +49,16 @@ public class SensorConfigController {
         }
     }
 
+    @PostMapping("/{sensorType}")
+    public SensorConfig create(@PathVariable String sensorType, @Valid @RequestBody SensorConfig config) {
+        config.setSensorType(sensorType);
+        try {
+            return service.create(config);
+        } catch (IllegalArgumentException iae) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, iae.getMessage(), iae);
+        }
+    }
+
     @PutMapping("/{sensorType}")
     public SensorConfig update(@PathVariable String sensorType, @Valid @RequestBody SensorConfig config) {
         try {


### PR DESCRIPTION
## Summary
- add POST endpoint at `/api/sensor-config/{sensorType}` to create configs directly for a given sensor type

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b94638fad8832895040bf9e61c2a83