### PR TITLE
Add toggle for connection pool metrics logging

### DIFF
--- a/src/main/java/se/hydroleaf/config/ConnectionPoolMetrics.java
+++ b/src/main/java/se/hydroleaf/config/ConnectionPoolMetrics.java
@@ -3,6 +3,7 @@ package se.hydroleaf.config;
 import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.HikariPoolMXBean;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -18,17 +19,21 @@ import javax.sql.DataSource;
 public class ConnectionPoolMetrics {
 
     private final HikariDataSource dataSource;
+    private final boolean enabled;
 
-    public ConnectionPoolMetrics(DataSource dataSource) {
+    public ConnectionPoolMetrics(
+            DataSource dataSource,
+            @Value("${metrics.connection-pool.enabled:true}") boolean enabled) {
         this.dataSource = dataSource instanceof HikariDataSource
                 ? (HikariDataSource) dataSource
                 : null;
+        this.enabled = enabled;
     }
 
     @Scheduled(fixedDelayString = "${metrics.connection-pool.log-interval:60000}")
     public void logMetrics() {
-        if (dataSource == null) {
-            return; // DataSource not HikariCP; nothing to log
+        if (!enabled || dataSource == null) {
+            return; // Logging disabled or DataSource not HikariCP; nothing to log
         }
         HikariPoolMXBean mxBean = dataSource.getHikariPoolMXBean();
         int active = mxBean.getActiveConnections();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,3 +53,6 @@ management:
     web:
       exposure:
         include: health,info,metrics,prometheus
+metrics:
+  connection-pool:
+    enabled: true

--- a/src/test/java/se/hydroleaf/config/ConnectionPoolMetricsTest.java
+++ b/src/test/java/se/hydroleaf/config/ConnectionPoolMetricsTest.java
@@ -1,0 +1,22 @@
+package se.hydroleaf.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(OutputCaptureExtension.class)
+class ConnectionPoolMetricsTest {
+
+    @Test
+    void whenDisabledNoLogIsEmitted(CapturedOutput output) {
+        HikariDataSource dataSource = Mockito.mock(HikariDataSource.class);
+        ConnectionPoolMetrics metrics = new ConnectionPoolMetrics(dataSource, false);
+        metrics.logMetrics();
+        assertThat(output.getOut()).doesNotContain("HikariCP -");
+    }
+}


### PR DESCRIPTION
## Summary
- add `metrics.connection-pool.enabled` property and disable logging when false
- document metrics logging property with default enabled
- add unit test confirming no logs when connection pool metrics disabled

## Testing
- `mvn test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.3 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd55ea3e5083288d2315a5ee048910