### PR TITLE
Add note delete endpoint and store content as TEXT

### DIFF
--- a/src/main/java/se/hydroleaf/controller/NoteController.java
+++ b/src/main/java/se/hydroleaf/controller/NoteController.java
@@ -2,7 +2,9 @@ package se.hydroleaf.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,5 +37,11 @@ public class NoteController {
     @ResponseStatus(HttpStatus.CREATED)
     public Note createNote(@RequestBody Note note) {
         return noteService.save(note);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteNote(@PathVariable Long id) {
+        noteService.deleteById(id);
     }
 }

--- a/src/main/java/se/hydroleaf/model/Note.java
+++ b/src/main/java/se/hydroleaf/model/Note.java
@@ -34,6 +34,6 @@ public class Note {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime date;
 
-    @Column(nullable = false)
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 }

--- a/src/main/java/se/hydroleaf/service/NoteService.java
+++ b/src/main/java/se/hydroleaf/service/NoteService.java
@@ -24,4 +24,8 @@ public class NoteService {
     public List<Note> searchByContent(String query) {
         return noteRepository.findByContentContainingIgnoreCase(query);
     }
+
+    public void deleteById(Long id) {
+        noteRepository.deleteById(id);
+    }
 }

--- a/src/main/resources/migrations/V4__note_content_text.sql
+++ b/src/main/resources/migrations/V4__note_content_text.sql
@@ -1,0 +1,2 @@
+ALTER TABLE note
+    ALTER COLUMN content TYPE TEXT;


### PR DESCRIPTION
## Summary
- Allow longer note bodies by mapping `Note.content` to SQL TEXT
- Add DELETE /api/notes/{id} endpoint to remove notes
- Include Flyway migration to update existing databases

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f75655448328885841d8dd94e9cb