### PR TITLE
Add note update endpoint

### DIFF
--- a/src/main/java/se/hydroleaf/controller/NoteController.java
+++ b/src/main/java/se/hydroleaf/controller/NoteController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -43,5 +44,14 @@ public class NoteController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteNote(@PathVariable Long id) {
         noteService.deleteById(id);
+    }
+
+    @PutMapping("/{id}")
+    public Note updateNote(@PathVariable Long id, @RequestBody Note note) {
+        try {
+            return noteService.update(id, note);
+        } catch (IllegalArgumentException iae) {
+            throw new org.springframework.web.server.ResponseStatusException(HttpStatus.NOT_FOUND, iae.getMessage(), iae);
+        }
     }
 }

--- a/src/main/java/se/hydroleaf/service/NoteService.java
+++ b/src/main/java/se/hydroleaf/service/NoteService.java
@@ -28,4 +28,15 @@ public class NoteService {
     public void deleteById(Long id) {
         noteRepository.deleteById(id);
     }
+
+    public Note update(Long id, Note updated) {
+        return noteRepository.findById(id)
+                .map(existing -> {
+                    existing.setTitle(updated.getTitle());
+                    existing.setDate(updated.getDate());
+                    existing.setContent(updated.getContent());
+                    return noteRepository.save(existing);
+                })
+                .orElseThrow(() -> new IllegalArgumentException("Note not found"));
+    }
 }

--- a/src/test/java/se/hydroleaf/service/NoteServiceTest.java
+++ b/src/test/java/se/hydroleaf/service/NoteServiceTest.java
@@ -1,0 +1,53 @@
+package se.hydroleaf.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import se.hydroleaf.model.Note;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest(properties = "spring.flyway.enabled=false")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ActiveProfiles("test")
+@Import(NoteService.class)
+class NoteServiceTest {
+
+    @Autowired
+    private NoteService noteService;
+
+    @Test
+    void updateExistingNote() {
+        Note saved = noteService.save(Note.builder()
+                .title("Old")
+                .date(LocalDateTime.now())
+                .content("Initial")
+                .build());
+
+        Note updated = Note.builder()
+                .title("New")
+                .date(LocalDateTime.now())
+                .content("Updated")
+                .build();
+
+        Note result = noteService.update(saved.getId(), updated);
+        assertEquals("New", result.getTitle());
+        assertEquals("Updated", result.getContent());
+    }
+
+    @Test
+    void updateNonExistingNoteThrowsException() {
+        Note updated = Note.builder()
+                .title("New")
+                .date(LocalDateTime.now())
+                .content("Updated")
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> noteService.update(999L, updated));
+    }
+}


### PR DESCRIPTION
## Summary
- Allow updating existing notes through `/api/notes/{id}`
- Add service logic to persist edited note fields
- Cover note update behaviour with JPA test

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM for se.hydroleaf:demo: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c201cc9ac48328934a679d3b622657